### PR TITLE
Changes in test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ Find some useful links below:
         <version>x.x.x</version>
      </dependency>
 ```
+## Jenkins Build Status
+
+---
+
+|  Branch | Build Status |
+| :------ |:------------ |
+| master  | [![Build Status](https://wso2.org/jenkins/job/siddhi/job/siddhi-io-prometheus/badge/icon)](https://wso2.org/jenkins/job/siddhi/job/siddhi-io-prometheus/) |
+
+---
 
 ## Features
 

--- a/component/src/test/resources/testng.xml
+++ b/component/src/test/resources/testng.xml
@@ -20,10 +20,16 @@
   ~ under the License.
   -->
 
-<suite name="Siddhi-Io-Prometheus-Test-Suite">
+<suite name="Siddhi-IO-Prometheus-Test-Suite">
     <test name="Siddhi-io-prometheus-tests" enabled="true">
         <classes>
             <class name="org.wso2.extension.siddhi.io.prometheus.sink.ValidationTestcase"/>
+        </classes>
+    </test>
+    <test name="Prometheus sink run tests" enabled="false">
+        <!--Prometheus server and Pushgateway must be up and running for these test cases to pass-->
+        <classes>
+            <class name="org.wso2.extension.siddhi.io.prometheus.sink.SinkTestWithDocker"/>
             <class name="org.wso2.extension.siddhi.io.prometheus.sink.PrometheusSinkTest"/>
         </classes>
     </test>


### PR DESCRIPTION
## Purpose
> - Jenkins Build Status is missing in README.md
> - Some test cases are failing due to the requirement of running Prometheus Server and Push gateway.
 
## Goals
> - Add Jenkins Build Status inside README.md
> - Make changes in testng.xml to skip the test cases which needed Prometheus server and Push gateway to pass.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
> yes
 - Ran FindSecurityBugs plugin and verified report? 
 > yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
> yes

## Test environment
> - JDK version: 1.8
> - Operating system: Ubuntu 18.04
> - Prometheus release version: 2.5.0
