### PR TITLE
Add classes for prometheus-source

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-﻿Siddhi-io-prometheus
+﻿﻿Siddhi-io-prometheus
 ======================================
 
-The **siddhi-io-prometheus extension** is an extension to <a target="_blank" href="https://wso2.github.io/siddhi">Siddhi</a>. It publishes siddhi events as Prometheus metrics and expose them to Prometheus server.
+The **siddhi-io-prometheus extension** is an extension to <a target="_blank" href="https://wso2.github.io/siddhi">Siddhi</a>. The Prometheus-sink publishes Siddhi events as Prometheus metrics and expose them to Prometheus 
+server. The Prometheus-source retrieves Prometheus metrics from an endpoint and send them as 
+Siddhi events.
 
 ## Prerequisites
 
@@ -12,6 +14,9 @@ Find some useful links below:
 * <a target="_blank" href="https://github.com/wso2-extensions/siddhi-io-prometheus">Source code</a>
 * <a target="_blank" href="https://github.com/wso2-extensions/siddhi-io-prometheus/releases">Releases</a>
 * <a target="_blank" href="https://github.com/wso2-extensions/siddhi-io-prometheus/issues">Issue tracker</a>
+
+## Latest API Docs
+
 
 ## How to use
 
@@ -43,15 +48,6 @@ Find some useful links below:
 ---
 
 ## Features
-
-* <a target="_blank" href="https://wso2-extensions.github.io/siddhi-io-prometheus/api/1.0.0/#prometheus-sink">prometheus</a> (<a target="_blank" href="https://wso2.github.io/siddhi/documentation/siddhi-4.0/#sink">sink</a>)
-
-     The sink extension publishes events processed by WSO2 SP into Prometheus metrics and expose them to Prometheus server at the provided url. The created metrics will be published to Prometheus through,
-     
-     * 'server' publish mode : The metrics will be exposed using a http server.
-     * 'pushgateway' publish mode : The metrics will be pushed to Prometheus pushgateway. 
-     
-     The metric types that are supported by Prometheus sink are counter, gauge, histogram and summary. And the values and labels of the Prometheus metrics will be updated according to each event.
 
 
 ## How to contribute

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+~ Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 ~
 ~ WSO2 Inc. licenses this file to you under the Apache License,
 ~ Version 2.0 (the "License"); you may not use this file except
@@ -77,6 +77,14 @@
             <version>${tapestry-json.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.transport.http</groupId>
+            <artifactId>org.wso2.transport.http.netty</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.messaging</groupId>
+            <artifactId>org.wso2.carbon.messaging</artifactId>
+        </dependency>
     </dependencies>
     <profiles>
         <profile>
@@ -147,7 +155,7 @@
                                                     <port>9090</port>
                                                 </ports>
                                             </tcp>
-                                            <time>600000</time>
+                                            <time>6000</time>
                                         </wait>
                                     </run>
                                 </image>
@@ -166,7 +174,7 @@
                                                     <port>9091</port>
                                                 </ports>
                                             </tcp>
-                                            <time>600000</time>
+                                            <time>6000</time>
                                         </wait>
                                     </run>
                                 </image>
@@ -205,7 +213,6 @@
                             </suiteXmlFiles>
                         </configuration>
                     </plugin>
-
                 </plugins>
             </build>
         </profile>

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-~ Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 ~
 ~ WSO2 Inc. licenses this file to you under the Apache License,
 ~ Version 2.0 (the "License"); you may not use this file except

--- a/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/sink/PrometheusSink.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/sink/PrometheusSink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/sink/PrometheusSink.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/sink/PrometheusSink.java
@@ -414,10 +414,10 @@ public class PrometheusSink extends Sink {
         }
         switch (publishMode) {
             case PrometheusConstants.SERVER_PUBLISH_MODE:
-                collectorRegistry = prometheusMetricBuilder.setRegistry(serverURL);
+                collectorRegistry = prometheusMetricBuilder.setRegistry(serverURL, streamID);
                 break;
             case PrometheusConstants.PUSHGATEWAY_PUBLISH_MODE:
-                collectorRegistry = prometheusMetricBuilder.setRegistry(pushURL);
+                collectorRegistry = prometheusMetricBuilder.setRegistry(pushURL, streamID);
                 break;
             default:
                 //default execution is not needed
@@ -486,7 +486,7 @@ public class PrometheusSink extends Sink {
             prometheusMetricBuilder.registerMetric(valueAttribute);
         } catch (MalformedURLException e) {
             throw new ConnectionUnavailableException("Error in URL format in Prometheus sink associated with stream \'"
-                    + getStreamDefinition().getId() + "\'. \n " + e);
+                    + getStreamDefinition().getId() + "\'. \n ", e);
         }
     }
 

--- a/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/sink/PrometheusSink.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/sink/PrometheusSink.java
@@ -446,8 +446,8 @@ public class PrometheusSink extends Sink {
             } catch (IOException e) {
                 log.error("Unable to establish connection for Prometheus sink associated with " +
                                 "stream \'" + getStreamDefinition().getId() + "\' at " + pushURL);
-                throw new ConnectionUnavailableException("Unable to establish connection for Prometheus sink associated with " +
-                        "stream \'" + getStreamDefinition().getId() + "\' at " + pushURL, e);
+                throw new ConnectionUnavailableException("Unable to establish connection for Prometheus sink " +
+                        "associated with stream \'" + getStreamDefinition().getId() + "\' at " + pushURL, e);
             }
         }
     }

--- a/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/sink/PrometheusSink.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/sink/PrometheusSink.java
@@ -45,6 +45,7 @@ import org.wso2.siddhi.query.api.exception.AttributeNotExistException;
 
 import java.io.IOException;
 import java.net.BindException;
+import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Enumeration;
@@ -294,6 +295,7 @@ public class PrometheusSink extends Sink {
     private PrometheusMetricBuilder prometheusMetricBuilder;
     private HTTPServer server;
     private PushGateway pushGateway;
+    private CollectorRegistry collectorRegistry;
     private String registeredMetrics;
     private ConfigReader configReader;
 
@@ -419,6 +421,16 @@ public class PrometheusSink extends Sink {
         if (PrometheusUtil.validateQuantiles(quantileValues, streamID)) {
             prometheusMetricBuilder.setQuantiles(quantileValues, quantileError);
         }
+        switch (publishMode) {
+            case PrometheusConstants.SERVER_PUBLISH_MODE:
+                collectorRegistry = prometheusMetricBuilder.setRegistry(serverURL);
+                break;
+            case PrometheusConstants.PUSHGATEWAY_PUBLISH_MODE:
+                collectorRegistry = prometheusMetricBuilder.setRegistry(pushURL);
+                break;
+            default:
+                //default will never be executed
+        }
     }
 
     @Override
@@ -452,7 +464,7 @@ public class PrometheusSink extends Sink {
     @Override
     public void connect() throws ConnectionUnavailableException {
         try {
-            prometheusMetricBuilder.registerMetric(valueAttribute, publishMode);
+            prometheusMetricBuilder.registerMetric(valueAttribute);
             URL target;
             switch (publishMode) {
                 case PrometheusConstants.SERVER_PUBLISH_MODE:
@@ -487,7 +499,8 @@ public class PrometheusSink extends Sink {
 
     private void initiateServer(String host, int port) {
         try {
-            server = new HTTPServer(host, port);
+            InetSocketAddress address = new InetSocketAddress(host, port);
+            server = new HTTPServer(address, collectorRegistry);
         } catch (IOException e) {
             if (!(e instanceof BindException && e.getMessage().equals("Address already in use"))) {
                 log.error("Unable to establish connection for Prometheus sink associated with stream \'" +

--- a/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/sink/util/PrometheusMetricBuilder.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/sink/util/PrometheusMetricBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/sink/util/PrometheusMetricBuilder.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/sink/util/PrometheusMetricBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/sink/util/PrometheusMetricBuilder.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/sink/util/PrometheusMetricBuilder.java
@@ -26,8 +26,10 @@ import io.prometheus.client.Histogram;
 import io.prometheus.client.SimpleCollector;
 import io.prometheus.client.SimpleCollector.Builder;
 import io.prometheus.client.Summary;
-import org.wso2.extension.siddhi.io.prometheus.util.PrometheusConstants;
+import org.wso2.siddhi.core.exception.SiddhiAppCreationException;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.List;
 
 
@@ -67,13 +69,7 @@ public class PrometheusMetricBuilder {
         this.quantileError = quantileError;
     }
 
-    public void registerMetric(String valueAttribute, String buildMode) {
-        if (PrometheusConstants.SERVER_PUBLISH_MODE.equalsIgnoreCase(buildMode)) {
-            registry = CollectorRegistry.defaultRegistry;
-        }
-        if (PrometheusConstants.PUSHGATEWAY_PUBLISH_MODE.equalsIgnoreCase(buildMode)) {
-            registry = new CollectorRegistry();
-        }
+    public void registerMetric(String valueAttribute) {
         metricsCollector = buildMetric(valueAttribute).register(registry);
     }
 
@@ -143,5 +139,16 @@ public class PrometheusMetricBuilder {
             }
             default: //default will never be executed
         }
+    }
+
+    public CollectorRegistry setRegistry(String url) {
+        URL target;
+        try {
+            target = new URL(url);
+            registry = PrometheusRegistryHolder.retrieveRegistry(target.getHost(), target.getPort());
+        } catch (MalformedURLException e) {
+            throw new SiddhiAppCreationException("Error in URL " + e);
+        }
+        return registry;
     }
 }

--- a/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/sink/util/PrometheusMetricBuilder.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/sink/util/PrometheusMetricBuilder.java
@@ -141,13 +141,14 @@ public class PrometheusMetricBuilder {
         }
     }
 
-    public CollectorRegistry setRegistry(String url) {
+    public CollectorRegistry setRegistry(String url, String streamID) {
         URL target;
         try {
             target = new URL(url);
             registry = PrometheusRegistryHolder.retrieveRegistry(target.getHost(), target.getPort());
         } catch (MalformedURLException e) {
-            throw new SiddhiAppCreationException("Error in URL " + e);
+            throw new SiddhiAppCreationException("Error in the URL format of Prometheus sink associated with stream \'"
+                    + streamID + "\'. \n ", e);
         }
         return registry;
     }

--- a/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/sink/util/PrometheusRegistryHolder.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/sink/util/PrometheusRegistryHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/sink/util/PrometheusRegistryHolder.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/sink/util/PrometheusRegistryHolder.java
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
@@ -38,7 +37,6 @@ class PrometheusRegistryHolder {
         CollectorRegistry registry = new CollectorRegistry();
         registryMap.put(hashKey, registry);
         return registry;
-
     }
 
     static CollectorRegistry retrieveRegistry(String host, int port) {
@@ -49,6 +47,4 @@ class PrometheusRegistryHolder {
             return registerRegistry(hashKey);
         }
     }
-
-
 }

--- a/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/sink/util/PrometheusRegistryHolder.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/sink/util/PrometheusRegistryHolder.java
@@ -1,0 +1,54 @@
+
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.extension.siddhi.io.prometheus.sink.util;
+
+import io.prometheus.client.CollectorRegistry;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A singleton class to initialize registry.
+ */
+class PrometheusRegistryHolder {
+
+    private static Map<Integer, CollectorRegistry> registryMap = new HashMap<>();
+
+    private PrometheusRegistryHolder() {
+    }
+
+    private static CollectorRegistry registerRegistry(int hashKey) {
+        CollectorRegistry registry = new CollectorRegistry();
+        registryMap.put(hashKey, registry);
+        return registry;
+
+    }
+
+    static CollectorRegistry retrieveRegistry(String host, int port) {
+        int hashKey = (host + port).hashCode();
+        if (registryMap.containsKey(hashKey)) {
+            return registryMap.get(hashKey);
+        } else {
+            return registerRegistry(hashKey);
+        }
+    }
+
+
+}

--- a/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/source/MetricType.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/source/MetricType.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.extension.siddhi.io.prometheus.source;
+
+import org.wso2.extension.siddhi.io.prometheus.util.PrometheusConstants;
+import org.wso2.siddhi.core.exception.SiddhiAppCreationException;
+
+import java.util.Locale;
+
+/**
+ * This specifies the metric types that are supported by Prometheus
+ */
+public enum MetricType {
+
+    COUNTER,
+    GAUGE,
+    SUMMARY,
+    HISTOGRAM;
+
+    public static MetricType assignMetricType(String metricTypeString,  String streamID) {
+        MetricType metricType;
+        switch (metricTypeString.trim().toUpperCase(Locale.ENGLISH)) {
+            case "COUNTER": {
+                metricType = MetricType.COUNTER;
+                break;
+            }
+            case "GAUGE": {
+                metricType = MetricType.GAUGE;
+                break;
+            }
+            case "HISTOGRAM": {
+                metricType = MetricType.HISTOGRAM;
+                break;
+            }
+            case "SUMMARY": {
+                metricType = MetricType.SUMMARY;
+                break;
+            }
+            default: {
+                throw new SiddhiAppCreationException("The \'metric.type\' field in " +
+                        PrometheusConstants.PROMETHEUS_SOURCE + " associated " +
+                        "with stream \'" + streamID + "\' contains illegal value");
+            }
+        }
+        return metricType;
+    }
+
+    public static String getMetricTypeString(MetricType metricType) {
+        switch (metricType) {
+            case COUNTER: {
+                return "counter";
+            }
+            case GAUGE: {
+                return "gauge";
+            }
+            case HISTOGRAM: {
+                return "histogram";
+            }
+            case SUMMARY: {
+                return "summary";
+            }
+            default: {
+                //default will never be executed
+                return null;
+            }
+        }
+    }
+}
+

--- a/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/source/PrometheusHTTPClientListener.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/source/PrometheusHTTPClientListener.java
@@ -54,5 +54,4 @@ public class PrometheusHTTPClientListener implements HttpConnectorListener {
     HTTPCarbonMessage getHttpResponseMessage() {
         return httpMessage;
     }
-
 }

--- a/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/source/PrometheusHTTPClientListener.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/source/PrometheusHTTPClientListener.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.extension.siddhi.io.prometheus.source;
+
+import org.wso2.transport.http.netty.contract.HttpConnectorListener;
+import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
+import org.wso2.transport.http.netty.message.Http2PushPromise;
+
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * {@code PrometheusHTTPClientListener} Handles the HTTP client listener.
+ */
+public class PrometheusHTTPClientListener implements HttpConnectorListener {
+    private final CountDownLatch latch;
+    private HTTPCarbonMessage httpMessage;
+
+    PrometheusHTTPClientListener(CountDownLatch latch) {
+        this.latch = latch;
+    }
+
+    @Override
+    public void onMessage(HTTPCarbonMessage httpMessage) {
+        this.httpMessage = httpMessage;
+        latch.countDown();
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+        latch.countDown();
+    }
+
+    @Override
+    public void onPushPromise(Http2PushPromise pushPromise) {
+
+    }
+
+    HTTPCarbonMessage getHttpResponseMessage() {
+        return httpMessage;
+    }
+
+}

--- a/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/source/PrometheusMetricAnalyser.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/source/PrometheusMetricAnalyser.java
@@ -73,7 +73,7 @@ class PrometheusMetricAnalyser {
             String error = "The specified metric cannot be found inside the http response from the " + targetURL +
                     " of " + PrometheusConstants.PROMETHEUS_SOURCE + " associated with stream \'" + streamID +
                     "\'.";
-            log.error(error, new SiddhiAppRuntimeException(error));
+            throw new SiddhiAppRuntimeException(error);
         }
         assignHelpString(metricSamples, index);
         if (!checkMetricType(metricSamples, index)) {
@@ -81,7 +81,7 @@ class PrometheusMetricAnalyser {
                     "matching with the specified metric type \'" + MetricType.getMetricTypeString(metricType) +
                     "\' in the " + PrometheusConstants.PROMETHEUS_SOURCE + " associated with stream \'" +
                     streamID + "\'. ";
-            log.error(error, new SiddhiAppRuntimeException(error));
+            throw new SiddhiAppRuntimeException(error);
         }
         List<String> retrievedMetrics = metricSamples.stream().filter(
                 response -> response.startsWith(metricName)).collect(Collectors.toList());
@@ -125,11 +125,14 @@ class PrometheusMetricAnalyser {
                         " \'" + targetURL + "\' is not matching with the specified metric in the " +
                         PrometheusConstants.PROMETHEUS_SOURCE + " associated with stream \'" + streamID +
                         "\'. ";
-                log.error(error, new SiddhiAppRuntimeException(error));
+                throw new SiddhiAppRuntimeException(error);
             }
         }
         lastValidSample.clear();
         lastValidSample.addAll(filteredMetrics);
+        if (log.isDebugEnabled()) {
+            log.debug("The specified metrics is found inside the HTTP response.");
+        }
         generateMaps(filteredMetrics);
     }
 

--- a/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/source/PrometheusMetricAnalyser.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/source/PrometheusMetricAnalyser.java
@@ -246,5 +246,4 @@ class PrometheusMetricAnalyser {
     List<String> getLastValidSamples() {
         return this.lastValidSample;
     }
-
 }

--- a/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/source/PrometheusMetricAnalyser.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/source/PrometheusMetricAnalyser.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.extension.siddhi.io.prometheus.source;
+
+import org.apache.log4j.Logger;
+import org.wso2.extension.siddhi.io.prometheus.util.PrometheusConstants;
+import org.wso2.siddhi.core.exception.SiddhiAppRuntimeException;
+import org.wso2.siddhi.core.stream.input.source.SourceEventListener;
+import org.wso2.siddhi.query.api.definition.Attribute;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * This class analyses the response from http response, filter the metrics and generate maps according to
+ * metric label-values.
+ */
+class PrometheusMetricAnalyser {
+
+    private static final Logger log = Logger.getLogger(PrometheusMetricAnalyser.class);
+    private final String metricName;
+    private final MetricType metricType;
+    private final SourceEventListener sourceEventListener;
+    private final List<String> lastValidSample = new ArrayList<>();
+    private final Attribute.Type valueType;
+    private final String metricJob;
+    private final String metricInstance;
+    private final Map<String, String> metricGroupingKey;
+    private String metricHelp;
+
+
+    PrometheusMetricAnalyser(String metricName, MetricType metricType, String metricJob, String metricInstance,
+                             Map<String, String> metricGroupingKey, Attribute.Type valueType,
+                             SourceEventListener sourceEventListener) {
+        this.metricName = metricName;
+        this.metricType = metricType;
+        this.metricJob = metricJob;
+        this.metricInstance = metricInstance;
+        this.metricGroupingKey = metricGroupingKey;
+        this.valueType = valueType;
+        this.sourceEventListener = sourceEventListener;
+    }
+
+    void analyseMetrics(List<String> metricSamples, String targetURL, String streamID) {
+        int index = -1;
+        for (int i = 0; i < metricSamples.size(); i++) {
+            if ((metricSamples.get(i)).startsWith("# TYPE " + metricName + " ")) {
+                index = i;
+                break;
+            }
+        }
+        if (index == -1) {
+            String error = "The specified metric cannot be found inside the http response from the " + targetURL +
+                    " of " + PrometheusConstants.PROMETHEUS_SOURCE + " associated with stream \'" + streamID +
+                    "\'.";
+            log.error(error, new SiddhiAppRuntimeException(error));
+        }
+        assignHelpString(metricSamples, index);
+        if (!checkMetricType(metricSamples, index)) {
+            String error = " The type of the metric retrieved from the target \'" + targetURL + "\' is not " +
+                    "matching with the specified metric type \'" + MetricType.getMetricTypeString(metricType) +
+                    "\' in the " + PrometheusConstants.PROMETHEUS_SOURCE + " associated with stream \'" +
+                    streamID + "\'. ";
+            log.error(error, new SiddhiAppRuntimeException(error));
+        }
+        List<String> retrievedMetrics = metricSamples.stream().filter(
+                response -> response.startsWith(metricName)).collect(Collectors.toList());
+        List<String> filteredMetrics = new ArrayList<>(retrievedMetrics);
+        if ((!metricJob.equals(PrometheusConstants.EMPTY_STRING) ||
+                !metricInstance.equals(PrometheusConstants.EMPTY_STRING) || !metricGroupingKey.isEmpty())) {
+            for (String sampleSingleLine : retrievedMetrics) {
+                Map<String, String> labelPairMap = filterMetric(sampleSingleLine);
+                if (!(metricJob.equals(PrometheusConstants.EMPTY_STRING))) {
+                    String job = labelPairMap.get("job");
+                    if (job == null || !job.equalsIgnoreCase(metricJob)) {
+                        filteredMetrics.remove(sampleSingleLine);
+                        continue;
+                    }
+                }
+                if (!(metricInstance.equals(PrometheusConstants.EMPTY_STRING))) {
+                    String instance = labelPairMap.get("instance");
+                    if (instance == null || !instance.equalsIgnoreCase(metricInstance)) {
+                        filteredMetrics.remove(sampleSingleLine);
+                        continue;
+                    }
+                }
+                if (metricGroupingKey != null) {
+                    for (Map.Entry<String, String> entry : metricGroupingKey.entrySet()) {
+                        String value = labelPairMap.get(entry.getKey());
+                        if (value != null) {
+                            if (!value.equalsIgnoreCase(entry.getValue())) {
+                                filteredMetrics.remove(sampleSingleLine);
+                                break;
+                            }
+                        } else {
+                            //if the grouping key not found in the metric,
+                            filteredMetrics.remove(sampleSingleLine);
+                            break;
+                        }
+                    }
+                }
+            }
+            if (filteredMetrics.isEmpty()) {
+                String error = " The job, instance or grouping key of the metric retrieved from the target at" +
+                        " \'" + targetURL + "\' is not matching with the specified metric in the " +
+                        PrometheusConstants.PROMETHEUS_SOURCE + " associated with stream \'" + streamID +
+                        "\'. ";
+                log.error(error, new SiddhiAppRuntimeException(error));
+            }
+        }
+        lastValidSample.clear();
+        lastValidSample.addAll(filteredMetrics);
+        generateMaps(filteredMetrics);
+    }
+
+    private void assignHelpString(List<String> metricSamples, int index) {
+        if (index == 0) {
+            this.metricHelp = PrometheusConstants.EMPTY_STRING;
+            return;
+        }
+        String helpString = metricSamples.get(index - 1);
+        if (!helpString.startsWith("# HELP " + metricName + " ")) {
+            this.metricHelp = PrometheusConstants.EMPTY_STRING;
+            return;
+        }
+        String[] metricHelpArray = helpString.split(" ", 4);
+        this.metricHelp = metricHelpArray[metricHelpArray.length - 1];
+    }
+
+    private void generateMaps(List<String> retrievedMetrics) {
+        for (String sampleSingleLine : retrievedMetrics) {
+            Map<String, Object> metricMap = new LinkedHashMap<>();
+            metricMap.put(PrometheusConstants.MAP_NAME, metricName);
+            metricMap.put(PrometheusConstants.MAP_TYPE, MetricType.getMetricTypeString(metricType));
+            metricMap.put(PrometheusConstants.MAP_HELP, metricHelp);
+
+            String sampleName = sampleSingleLine.substring(0, sampleSingleLine.indexOf("{"));
+            Object value = setMetricValue(sampleSingleLine.substring(sampleSingleLine.indexOf("}") + 1).trim());
+            Map<String, String> labelValueMap = filterMetric(sampleSingleLine);
+            if (sampleName.equals(metricName)) {
+                metricMap.put(PrometheusConstants.MAP_SAMPLE_SUBTYPE, PrometheusConstants.SUBTYPE_NULL);
+            }
+            if (sampleName.equals(metricName + PrometheusConstants.BUCKET_POSTFIX)) {
+                metricMap.put(PrometheusConstants.MAP_SAMPLE_SUBTYPE, PrometheusConstants.SUBTYPE_BUCKET);
+            }
+            if (sampleName.equals(metricName + PrometheusConstants.COUNT_POSTFIX)) {
+                metricMap.put(PrometheusConstants.MAP_SAMPLE_SUBTYPE, PrometheusConstants.SUBTYPE_COUNT);
+                addLeAndQuantileKeys(labelValueMap);
+            }
+            if (sampleName.equals(metricName + PrometheusConstants.SUM_POSTFIX)) {
+                metricMap.put(PrometheusConstants.MAP_SAMPLE_SUBTYPE, PrometheusConstants.SUBTYPE_SUM);
+                addLeAndQuantileKeys(labelValueMap);
+            }
+            for (Map.Entry<String, String> entry : labelValueMap.entrySet()) {
+                metricMap.put(entry.getKey(), entry.getValue());
+            }
+            metricMap.put(PrometheusConstants.MAP_SAMPLE_VALUE, value);
+            handleEvent(metricMap);
+        }
+    }
+
+    private Object setMetricValue(String valueString) {
+        switch (valueType) {
+            case INT: {
+                valueString = valueString.substring(0, valueString.indexOf("."));
+                return Integer.parseInt(valueString);
+            }
+            case LONG: {
+                valueString = valueString.substring(0, valueString.indexOf("."));
+                return Long.parseLong(valueString);
+            }
+            case FLOAT: {
+                return Float.parseFloat(valueString);
+            }
+            case DOUBLE: {
+                return Double.parseDouble(valueString);
+            }
+            default: {
+                //default will never be executed
+                return null;
+            }
+        }
+    }
+
+    private void addLeAndQuantileKeys(Map<String, String> labelValueMap) {
+        switch (metricType) {
+            case HISTOGRAM:
+                labelValueMap.put(PrometheusConstants.LE_KEY, PrometheusConstants.EMPTY_STRING);
+                break;
+            case SUMMARY:
+                labelValueMap.put(PrometheusConstants.QUANTILE_KEY, PrometheusConstants.EMPTY_STRING);
+                break;
+            default:
+                //default will never be executed.
+        }
+    }
+
+    private void handleEvent(Map<String, Object> metricMap) {
+        sourceEventListener.onEvent(metricMap, null);
+    }
+
+    /**
+     * This method analyses a single line of the metric response and returns a label-value map
+     */
+    private Map<String, String> filterMetric(String metricSample) {
+        String[] labelList = metricSample.substring(metricSample.indexOf("{") + 1, metricSample.indexOf("}"))
+                .split(",");
+        Map<String, String> labelMap = new LinkedHashMap<>();
+        Arrays.stream(labelList).forEach(labelEntry -> {
+            String[] entry = labelEntry.split("=");
+            if (entry.length == 2) {
+                String label = entry[0];
+                String value = entry[1].substring(1, entry[1].length() - 1);
+                labelMap.put(label, value);
+            }
+        });
+        return labelMap;
+    }
+
+    private boolean checkMetricType(List<String> metricSamples, int index) {
+        String[] metricTypeArray = metricSamples.get(index).split(" ", 4);
+        String metricTypeResponse = metricTypeArray[metricTypeArray.length - 1];
+        return metricTypeResponse.equalsIgnoreCase(MetricType.getMetricTypeString(metricType));
+    }
+
+    List<String> getLastValidSamples() {
+        return this.lastValidSample;
+    }
+
+}

--- a/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/source/PrometheusScraper.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/source/PrometheusScraper.java
@@ -82,7 +82,6 @@ public class PrometheusScraper implements Runnable {
     private CompletionCallback completionCallback;
     private PrometheusMetricAnalyser metricAnalyser;
     private HttpWsConnectorFactory httpConnectorFactory = new DefaultHttpWsConnectorFactory();
-    private HTTPCarbonMessage httpRequest;
 
     PrometheusScraper(String targetURL, String scheme, long scrapeTimeout,
                       List<Header> headers, SourceEventListener sourceEventListener, String streamName) {
@@ -136,16 +135,15 @@ public class PrometheusScraper implements Runnable {
 
     private void retrieveMetricSamples() throws ConnectionUnavailableException {
         List<String> responseMetrics = sendRequest();
-        String errorMessage = null;
         if (responseMetrics == null) {
-            errorMessage = "Error occurred while retrieving metrics at " + targetURL + ". Error : Response is null.";
+            log.error("Error occurred while retrieving metrics at " + targetURL + ". Error : Response is null.",
+                    new SiddhiAppRuntimeException("Error occurred while retrieving metrics at " + targetURL + ". " +
+                            "Error : Response is null."));
         } else {
             if (responseMetrics.isEmpty()) {
-                errorMessage = "The target at " + targetURL + " returns an empty response";
+                log.error("The target at " + targetURL + " returns an empty response",
+                        new SiddhiAppRuntimeException("The target at " + targetURL + " returns an empty response"));
             }
-        }
-        if (errorMessage != null) {
-            log.error(errorMessage, new SiddhiAppRuntimeException(errorMessage));
         }
         if (!responseMetrics.equals(metricSamples)) {
             metricSamples = responseMetrics;

--- a/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/source/PrometheusScraper.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/source/PrometheusScraper.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.extension.siddhi.io.prometheus.source;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.base64.Base64;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import org.apache.log4j.Logger;
+import org.wso2.carbon.messaging.Header;
+import org.wso2.extension.siddhi.io.prometheus.util.PrometheusConstants;
+import org.wso2.extension.siddhi.io.prometheus.util.PrometheusSourceUtil;
+import org.wso2.siddhi.core.exception.ConnectionUnavailableException;
+import org.wso2.siddhi.core.exception.SiddhiAppRuntimeException;
+import org.wso2.siddhi.core.stream.input.source.SourceEventListener;
+import org.wso2.siddhi.query.api.definition.Attribute;
+import org.wso2.transport.http.netty.common.Constants;
+import org.wso2.transport.http.netty.config.SenderConfiguration;
+import org.wso2.transport.http.netty.contract.HttpClientConnector;
+import org.wso2.transport.http.netty.contract.HttpResponseFuture;
+import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
+import org.wso2.transport.http.netty.contractimpl.DefaultHttpWsConnectorFactory;
+import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
+import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.MalformedURLException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.wso2.extension.siddhi.io.prometheus.util.PrometheusConstants.EMPTY_STRING;
+
+/**
+ * This class creates and sends an http request to the target-URL according to user inputs. And it transfers the
+ * retrieved data to {@code PrometheusMetricAnalyser} class.
+ */
+public class PrometheusScraper implements Runnable {
+    private static final Logger log = Logger.getLogger(PrometheusScraper.class);
+    private final String targetURL;
+    private final long scrapeTimeout;
+    private final String scheme;
+    private final List<Header> headers;
+    private final SourceEventListener sourceEventListener;
+    private final String streamName;
+    private boolean isPaused = false;
+    private List<String> metricSamples = new ArrayList<>();
+    private HttpClientConnector httpClientConnector;
+    private Map<String, String> urlProperties;
+    private String userName = EMPTY_STRING;
+    private String password = EMPTY_STRING;
+    private String clientStoreFile;
+    private String clientStorePassword;
+    private List<String> lastValidSamples;
+    private CompletionCallback completionCallback;
+    private PrometheusMetricAnalyser metricAnalyser;
+    private HttpWsConnectorFactory httpConnectorFactory = new DefaultHttpWsConnectorFactory();
+    private HTTPCarbonMessage httpRequest;
+
+    PrometheusScraper(String targetURL, String scheme, long scrapeTimeout,
+                      List<Header> headers, SourceEventListener sourceEventListener, String streamName) {
+        this.targetURL = targetURL;
+        this.scheme = scheme;
+        this.scrapeTimeout = scrapeTimeout;
+        this.headers = headers;
+        this.sourceEventListener = sourceEventListener;
+        this.streamName = streamName;
+    }
+
+    void setMetricProperties(String metricName, MetricType metricType, String metricJob,
+                             String metricInstance, Map<String, String> metricGroupingKey,
+                             Attribute.Type valueType) {
+        this.metricAnalyser = new PrometheusMetricAnalyser(metricName, metricType, metricJob, metricInstance,
+                metricGroupingKey, valueType, sourceEventListener);
+    }
+
+
+    void setAuthorizationCredentials(String userName, String password) {
+        this.userName = userName;
+        this.password = password;
+    }
+
+    void setHttpsProperties(String clientStoreFile, String clientStorePassword) {
+        this.clientStoreFile = clientStoreFile;
+        this.clientStorePassword = clientStorePassword;
+
+    }
+
+    void setCompletionCallback(CompletionCallback completionCallback) {
+        this.completionCallback = completionCallback;
+    }
+
+    void createConnectionChannel() {
+        try {
+            urlProperties = PrometheusSourceUtil.getURLProperties(targetURL, scheme);
+        } catch (MalformedURLException e) {
+            //target URL is already validated.
+        }
+        SenderConfiguration senderConfiguration = PrometheusSourceUtil.getSenderConfigurations(urlProperties,
+                clientStoreFile, clientStorePassword);
+        senderConfiguration.setSocketIdleTimeout((int) (scrapeTimeout * 1000));
+        if (!(PrometheusSourceUtil.checkEmptyString(userName) || PrometheusSourceUtil.checkEmptyString(password))) {
+            String basicAuthHeader = "Basic " + encode(userName + ":" + password);
+            headers.add(new Header(PrometheusConstants.AUTHORIZATION_HEADER, basicAuthHeader));
+        }
+        httpClientConnector = httpConnectorFactory.createHttpClientConnector(new HashMap<>(),
+                senderConfiguration);
+    }
+
+    private void retrieveMetricSamples() throws ConnectionUnavailableException {
+        List<String> responseMetrics = sendRequest();
+        String errorMessage = null;
+        if (responseMetrics == null) {
+            errorMessage = "Error occurred while retrieving metrics at " + targetURL + ". Error : Response is null.";
+        } else {
+            if (responseMetrics.isEmpty()) {
+                errorMessage = "The target at " + targetURL + " returns an empty response";
+            }
+        }
+        if (errorMessage != null) {
+            log.error(errorMessage, new SiddhiAppRuntimeException(errorMessage));
+        }
+        if (!responseMetrics.equals(metricSamples)) {
+            metricSamples = responseMetrics;
+            metricAnalyser.analyseMetrics(metricSamples, targetURL, streamName);
+            this.lastValidSamples = metricAnalyser.getLastValidSamples();
+        }
+    }
+
+    private String encode(String userNamePassword) {
+        ByteBuf byteBuf = Unpooled.wrappedBuffer(userNamePassword.getBytes(StandardCharsets.UTF_8));
+        ByteBuf encodedByteBuf = Base64.encode(byteBuf);
+        return encodedByteBuf.toString(StandardCharsets.UTF_8);
+    }
+
+    private List<String> sendRequest() throws ConnectionUnavailableException {
+        List<String> responsePayload = new ArrayList<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        HTTPCarbonMessage carbonMessage = generateCarbonMessage();
+        HttpResponseFuture httpResponseFuture = httpClientConnector.send(carbonMessage);
+        PrometheusHTTPClientListener httpListener = new PrometheusHTTPClientListener(latch);
+        httpResponseFuture.setHttpConnectorListener(httpListener);
+        BufferedReader bufferedReader = null;
+        try {
+            if (latch.await(scrapeTimeout + 10, TimeUnit.SECONDS)) {
+                HTTPCarbonMessage response = httpListener.getHttpResponseMessage();
+                bufferedReader = new BufferedReader(new InputStreamReader(
+                        new HttpMessageDataStreamer(response).getInputStream(), Charset.defaultCharset()));
+                int statusCode = response.getNettyHttpResponse().status().code();
+                if (statusCode == 200) {
+                    responsePayload = bufferedReader.lines().collect(Collectors.toList());
+                } else {
+                    String errorMessage = "Error occurred while retrieving metrics. HTTP error code: " +
+                            statusCode;
+                    throw new ConnectionUnavailableException(errorMessage);
+                }
+            }
+        } catch (InterruptedException e) {
+            log.error(" Interrupted exception thrown in " + PrometheusConstants.PROMETHEUS_SOURCE + " associated with" +
+                    " stream " + streamName + " while sending request.", e);
+        } finally {
+            if (bufferedReader != null) {
+                try {
+                    bufferedReader.close();
+                } catch (IOException e) {
+                    log.error(" IO exception thrown in " + PrometheusConstants.PROMETHEUS_SOURCE + " associated with" +
+                            " stream " + streamName + " while closing the Buffered reader.", e);
+                }
+            }
+        }
+        return responsePayload;
+    }
+
+    private HTTPCarbonMessage generateCarbonMessage() {
+        HttpMethod httpReqMethod = new HttpMethod(PrometheusConstants.DEFAULT_HTTP_METHOD);
+        HTTPCarbonMessage carbonMessage = new HTTPCarbonMessage(new DefaultHttpRequest(HttpVersion.HTTP_1_1,
+                httpReqMethod, EMPTY_STRING));
+        carbonMessage.setProperty(Constants.PROTOCOL, urlProperties.get(Constants.PROTOCOL));
+        carbonMessage.setProperty(Constants.TO, urlProperties.get(Constants.TO));
+        carbonMessage.setProperty(Constants.HTTP_HOST, urlProperties.get(Constants.HTTP_HOST));
+        carbonMessage.setProperty(Constants.HTTP_PORT, Integer.valueOf(urlProperties.get(Constants.HTTP_PORT)));
+        carbonMessage.setProperty(Constants.HTTP_METHOD, PrometheusConstants.DEFAULT_HTTP_METHOD);
+        carbonMessage.setProperty(Constants.REQUEST_URL, urlProperties.get(Constants.REQUEST_URL));
+        HttpHeaders httpHeaders = carbonMessage.getHeaders();
+        httpHeaders.set(Constants.HTTP_HOST, carbonMessage.getProperty(Constants.HTTP_HOST));
+        if (headers != null) {
+            for (Header header : headers) {
+                httpHeaders.set(header.getName(), header.getValue());
+            }
+        }
+        httpHeaders.set(PrometheusConstants.HTTP_CONTENT_TYPE, PrometheusConstants.TEXT_PLAIN);
+        httpHeaders.set(PrometheusConstants.HTTP_METHOD, PrometheusConstants.DEFAULT_HTTP_METHOD);
+        carbonMessage.completeMessage();
+        return carbonMessage;
+    }
+
+    @Override
+    public void run() {
+        if (!isPaused) {
+            try {
+                retrieveMetricSamples();
+            } catch (ConnectionUnavailableException e) {
+                completionCallback.handle(e);
+            }
+        }
+    }
+
+    void pause() {
+        isPaused = true;
+    }
+
+    void resume() {
+        isPaused = false;
+    }
+
+    List<String> getLastValidResponse() {
+        return this.lastValidSamples;
+    }
+
+    void setLastValidResponse(List<String> lastValidResponse) {
+        this.lastValidSamples = lastValidResponse;
+    }
+
+    void clearPrometheusScraper() {
+        if (metricSamples != null) {
+            metricSamples.clear();
+        }
+        if (lastValidSamples != null) {
+            lastValidSamples.clear();
+        }
+    }
+
+    void clearConnectorFactory() {
+        try {
+            httpConnectorFactory.shutdown();
+        } catch (InterruptedException e) {
+            log.error(" Interrupted exception thrown in " + PrometheusConstants.PROMETHEUS_SOURCE + " associated with" +
+                    " stream " + streamName + " while disconnecting.", e);
+        }
+    }
+
+    /**
+     * A callback function to be notified when {@code PrometheusScraper} throws an Error.
+     */
+    public interface CompletionCallback {
+        /**
+         * Handle errors from {@link PrometheusScraper}.
+         *
+         * @param error the error.
+         */
+        void handle(Throwable error);
+    }
+}

--- a/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/source/PrometheusSource.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/source/PrometheusSource.java
@@ -523,8 +523,6 @@ public class PrometheusSource extends Source {
     @Override
     public void restoreState(Map<String, Object> map) {
         prometheusScraper.setLastValidResponse((List<String>) map.get(PrometheusConstants.LAST_RETRIEVED_SAMPLES));
-
     }
-
 }
 

--- a/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/source/PrometheusSource.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/source/PrometheusSource.java
@@ -1,0 +1,528 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.extension.siddhi.io.prometheus.source;
+
+import org.wso2.carbon.messaging.Header;
+import org.wso2.extension.siddhi.io.prometheus.util.PrometheusConstants;
+import org.wso2.extension.siddhi.io.prometheus.util.PrometheusSourceUtil;
+import org.wso2.siddhi.annotation.Example;
+import org.wso2.siddhi.annotation.Extension;
+import org.wso2.siddhi.annotation.Parameter;
+import org.wso2.siddhi.annotation.SystemParameter;
+import org.wso2.siddhi.annotation.util.DataType;
+import org.wso2.siddhi.core.config.SiddhiAppContext;
+import org.wso2.siddhi.core.exception.ConnectionUnavailableException;
+import org.wso2.siddhi.core.exception.SiddhiAppCreationException;
+import org.wso2.siddhi.core.exception.SiddhiAppRuntimeException;
+import org.wso2.siddhi.core.stream.input.source.Source;
+import org.wso2.siddhi.core.stream.input.source.SourceEventListener;
+import org.wso2.siddhi.core.util.config.ConfigReader;
+import org.wso2.siddhi.core.util.transport.OptionHolder;
+import org.wso2.siddhi.query.api.definition.Attribute;
+import org.wso2.siddhi.query.api.exception.AttributeNotExistException;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static org.wso2.extension.siddhi.io.prometheus.util.PrometheusConstants.EMPTY_STRING;
+
+/**
+ * Extension for siddhi to retrieve Prometheus metrics from an http endpoint.
+ **/
+@Extension(
+        name = "prometheus",
+        namespace = "source",
+        description = "The source consumes Prometheus metrics which are exported from the specified url as " +
+                "Siddhi events, by making http requests to the url. According to the source configuration, it " +
+                "analyses metrics from the text response and sends them as Siddhi events through key-value mapping." +
+                "The user can retrieve metrics of types including, counter, gauge, histogram and summary. Since the" +
+                " source retrieves the metrics from a text response of the target, it is advised to use \'string\' " +
+                "as the attribute type for the attributes that correspond to Prometheus metric labels. Further, the" +
+                " Prometheus metric value is passed through the event as 'value'. Therefore, it is advisable to " +
+                "have an attribute with the name 'value' in the stream. \nThe supported types for the attribute, " +
+                "'value' are INT, LONG, FLOAT and DOUBLE.",
+        parameters = {
+                @Parameter(name = "target.url",
+                        description = "This property specifies the target url where the Prometheus metrics are " +
+                                "exported in text format.",
+                        type = DataType.STRING),
+                @Parameter(
+                        name = "scrape.interval",
+                        description = "This property specifies the time interval in seconds within which the source " +
+                                "should make an HTTP request to the  provided target url.",
+                        defaultValue = "60",
+                        optional = true,
+                        type = {DataType.INT}
+                ),
+                @Parameter(
+                        name = "scrape.timeout",
+                        description = "This property is the time duration in seconds for a scrape request to get " +
+                                "timed-out if the server at the url does not respond.",
+                        defaultValue = "10",
+                        optional = true,
+                        type = {DataType.INT}
+                ),
+                @Parameter(
+                        name = "scheme",
+                        description = "This property specifies the scheme of the target URL.\n The supported schemes" +
+                                " are 'HTTP' and 'HTTPS'.",
+                        defaultValue = "HTTP",
+                        optional = true,
+                        type = {DataType.STRING}
+                ),
+                @Parameter(
+                        name = "metric.name",
+                        description = "This property specifies the name of the metrics that are to be fetched. The " +
+                                "metric name must match the regex format, i.e., [a-zA-Z_:][a-zA-Z0-9_:]* .",
+                        defaultValue = "Stream name",
+                        optional = true,
+                        type = {DataType.STRING}
+                ),
+                @Parameter(
+                        name = "metric.type",
+                        description = "This property specifies the type of the Prometheus metric that is required " +
+                                "to be fetched. \n The supported metric types are \'counter\', \'gauge\'," +
+                                "\" \'histogram\' and \'summary\'. ",
+                        type = {DataType.STRING}
+                ),
+                @Parameter(
+                        name = "username",
+                        description = "This property specifies the username that has to be added in the authorization" +
+                                " header of the HTTP request, if basic authentication is enabled at the target. It " +
+                                "is required to specify both username and password to enable basic authentication. " +
+                                "If one of the parameter is not given by user then an error is logged in the console.",
+                        defaultValue = "<empty_string>",
+                        optional = true,
+                        type = {DataType.STRING}
+                ),
+                @Parameter(
+                        name = "password",
+                        description = "This property specifies the password that has to be added in the authorization" +
+                                " header of the request, if the basic authentication is enabled at the target. It " +
+                                "is required to specify both the username and password to enable basic authentication" +
+                                ". If one of the parameter is not given by user, then an error is " +
+                                "logged in the console.",
+                        defaultValue = "<empty_string>",
+                        optional = true,
+                        type = {DataType.STRING}
+                ),
+                @Parameter(
+                        name = "client.truststore.file",
+                        description = "The file path to the location of the truststore to which the client needs to " +
+                                "send https requests through 'https' protocol.",
+                        defaultValue = "<empty_string>",
+                        optional = true,
+                        type = {DataType.STRING}
+                ),
+                @Parameter(
+                        name = "client.truststore.password",
+                        description = " The password for client-truststore to send https requests. A custom password " +
+                                "can be specified if required. ",
+                        defaultValue = "<empty_string>",
+                        optional = true,
+                        type = {DataType.STRING}
+                ),
+                @Parameter(
+                        name = "headers",
+                        description = "Headers that should be included as HTTP request headers in the request. " +
+                                "\nThe format of the supported input is as follows, \n" +
+                                "\"\'header1:value1\',\'header2:value2\'\"",
+                        defaultValue = "<empty_string>",
+                        optional = true,
+                        type = {DataType.STRING}
+                ),
+                @Parameter(
+                        name = "job",
+                        description = " This property defines the job name of the exported Prometheus metrics " +
+                                "that has to be fetched.",
+                        defaultValue = "<empty_string>",
+                        optional = true,
+                        type = {DataType.STRING}
+                ),
+                @Parameter(
+                        name = "instance",
+                        description = "This property defines the instance of the exported Prometheus metrics " +
+                                "that has to be fetched.",
+                        defaultValue = "<empty_string>",
+                        optional = true,
+                        type = {DataType.STRING}
+                ),
+                @Parameter(
+                        name = "grouping.key",
+                        description = "This parameter specifies the grouping key of the required metrics in " +
+                                "key-value pairs. Grouping key is used if the metrics are exported by Prometheus" +
+                                " pushGateway in order to distinguish the metrics from already existing metrics.\n " +
+                                "The expected format of the grouping key is as follows: \n" +
+                                "\"\'key1:value1\',\'key2:value2\'\"",
+                        defaultValue = "<empty_string>",
+                        optional = true,
+                        type = {DataType.STRING}
+                ),
+        },
+        examples = {
+                @Example(
+                        syntax = "@source(type= 'prometheus', target.url= 'http://localhost:9080/metrics', " +
+                                "metric.type= 'counter', metric.name= 'sweet_production_counter', @map(type= " +
+                                "‘keyvalue’))\n" +
+                                "define stream FooStream1(metric_name string, metric_type string, help string, " +
+                                "subtype string, name string, quantity string, value double);\n",
+                        description = "In this example, the prometheus source makes an http request to the " +
+                                "\'target.url\' and analyse the response. From the analysed response, the source " +
+                                "retrieves the Prometheus counter metrics with the name, 'sweet_production_counter' " +
+                                "and converts the filtered metrics into Siddhi events using the key-value mapper." +
+                                "\nThe generated maps will have keys and values as follows: \n" +
+                                "  metric_name  -> sweet_production_counter\n" +
+                                "  metric_type  -> counter\n" +
+                                "  help  -> <help_string_of_metric>\n" +
+                                "  subtype  -> null\n" +
+                                "  name -> <value_of_label_name>\n" +
+                                "  quantity -> <value_of_label_quantity>\n" +
+                                "  value -> <value_of_metric>\n"
+                ),
+                @Example(
+                        syntax = "@source(type= 'prometheus', target.url= 'http://localhost:9080/metrics', " +
+                                "metric.type= 'summary', metric.name= 'sweet_production_summary', @map(type= " +
+                                "‘keyvalue’))\n define stream FooStream2(metric_name string, metric_type string, help" +
+                                " string, subtype string, name string, quantity string, quantile string, value " +
+                                "double);\n",
+                        description = "In this example, the prometheus source makes an http request to the " +
+                                "\'target.url\' and analyses the response. From the analysed response, the source " +
+                                "retrieves the Prometheus summary metrics with the name, 'sweet_production_summary' " +
+                                "and converts the filtered metrics into Siddhi events using the key-value mapper." +
+                                "\nThe generated maps have keys and values as follows: \n" +
+                                "  metric_name  -> sweet_production_summary\n" +
+                                "  metric_type  -> summary\n" +
+                                "  help  -> <help_string_of_metric>\n" +
+                                "  subtype  -> <'sum'/'count'/'null'>\n" +
+                                "  name -> <value_of_label_name>\n" +
+                                "  quantity -> <value_of_label_quantity>\n" +
+                                "  quantile  -> <value of the quantile>\n" +
+                                "  value -> <value_of_metric>\n"
+                ),
+                @Example(
+                        syntax = "@source(type= 'prometheus', target.url= 'http://localhost:9080/metrics', " +
+                                "metric.type= 'histogram', metric.name= 'sweet_production_histogram', @map(type= " +
+                                "‘keyvalue’))\n" +
+                                "define stream FooStream3(metric_name string, metric_type string, help string, " +
+                                "subtype string, name string, quantity string, le string, value double);\n",
+                        description = "In this example, the prometheus source will make an http request to the " +
+                                "\'target.url\' and analyse the response. From the analysed response, the source " +
+                                "retrieves the Prometheus histogram metrics with name 'sweet_production_histogram' " +
+                                "and converts the filtered metrics into Siddhi events using the key-value mapper." +
+                                "\nThe generated maps will have keys and values as follows, \n" +
+                                "  metric_name  -> sweet_production_histogram\n" +
+                                "  metric_type  -> histogram\n" +
+                                "  help  -> <help_string_of_metric>\n" +
+                                "  subtype  -> <'sum'/'count'/'bucket'>\n" +
+                                "  name -> <value_of_label_name>\n" +
+                                "  quantity -> <value_of_label_quantity>\n" +
+                                "  le  -> <value of the bucket>\n" +
+                                "  value -> <value_of_metric>\n"
+                )
+        },
+        systemParameter = {
+                @SystemParameter(
+                        name = "scrapeInterval",
+                        description = "The default time interval in seconds for the Prometheus source to make HTTP " +
+                                "requests to the target URL.",
+                        defaultValue = "60",
+                        possibleParameters = "Any integer value"
+                ),
+                @SystemParameter(
+                        name = "scrapeTimeout",
+                        description = "This default time duration (in seconds) for an HTTP request to time-out if the" +
+                                " server at the URL does not respond. ",
+                        defaultValue = "10",
+                        possibleParameters = "Any integer value"
+                ),
+                @SystemParameter(
+                        name = "scheme",
+                        description = "The scheme of the target for Prometheus source to make HTTP requests." +
+                                " The supported schemes are HTTP and HTTPS.",
+                        defaultValue = "HTTP",
+                        possibleParameters = "HTTP or HTTPS"
+                ),
+                @SystemParameter(
+                        name = "username",
+                        description = "The username that has to be added in the authorization header of the HTTP " +
+                                "request, if basic authentication is enabled at the target. It is required to " +
+                                "specify both username and password to enable basic authentication. If one of " +
+                                "the parameter is not given by user then an error is logged in the console.",
+                        defaultValue = "<empty_string>",
+                        possibleParameters = "Any string"
+                ),
+                @SystemParameter(
+                        name = "password",
+                        description = "The password that has to be added in the authorization header of the HTTP " +
+                                "request, if basic authentication is enabled at the target. It is required to " +
+                                "specify both username and password to enable basic authentication. If one of" +
+                                " the parameter is not given by user then an error is logged in the console.",
+                        defaultValue = "<empty_string>",
+                        possibleParameters = "Any string"
+                ),
+                @SystemParameter(
+                        name = "trustStoreFile",
+                        description = "The default file path to the location of truststore that the client needs " +
+                                "to send for HTTPS requests through 'HTTPS' protocol.",
+                        defaultValue = "${carbon.home}/resources/security/client-truststore.jks",
+                        possibleParameters = "Any valid path for the truststore file"
+                ),
+                @SystemParameter(
+                        name = "trustStorePassword",
+                        description = "The default password for the client-truststore to send HTTPS requests.",
+                        defaultValue = "wso2carbon",
+                        possibleParameters = "Any string"
+                ),
+                @SystemParameter(
+                        name = "headers",
+                        description = "The headers that should be included as HTTP request headers in the scrape " +
+                                "request. \nThe format of the supported input is as follows, \n" +
+                                "\"\'header1:value1\',\'header2:value2\'\"",
+                        defaultValue = "<empty_string>",
+                        possibleParameters = "Any valid http headers"
+                ),
+                @SystemParameter(
+                        name = "job",
+                        description = " The default job name of the exported Prometheus metrics " +
+                                "that has to be fetched.",
+                        defaultValue = "<empty_string>",
+                        possibleParameters = "Any valid job name"
+                ),
+                @SystemParameter(
+                        name = "instance",
+                        description = "The default instance of the exported Prometheus metrics " +
+                                "that has to be fetched.",
+                        defaultValue = "<empty_string>",
+                        possibleParameters = "Any valid instance name"
+                ),
+                @SystemParameter(
+                        name = "groupingKey",
+                        description = "The default grouping key of the required Prometheus metrics in key-value " +
+                                "pairs. Grouping key is used if the metrics are exported by Prometheus pushGateway " +
+                                "in order to distinguish the metrics from already existing metrics. " +
+                                "\nThe expected format of the grouping key is as follows: \n" +
+                                "\"\'key1:value1\',\'key2:value2\'\"",
+                        defaultValue = "<empty_string>",
+                        possibleParameters = "Any valid grouping key pairs"
+                )
+        }
+)
+
+public class PrometheusSource extends Source {
+    private final ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+    private String targetURL;
+    private String streamName;
+    private String scheme;
+    private long scrapeIntervalInSeconds;
+
+    private PrometheusScraper prometheusScraper;
+
+    @Override
+    public void init(SourceEventListener sourceEventListener, OptionHolder optionHolder,
+                     String[] requestedTransportPropertyNames, ConfigReader configReader,
+                     SiddhiAppContext siddhiAppContext) {
+        streamName = sourceEventListener.getStreamDefinition().getId();
+        initPrometheusScraper(optionHolder, configReader, sourceEventListener, siddhiAppContext);
+        configureMetricAnalyser(optionHolder, configReader, siddhiAppContext);
+        prometheusScraper.createConnectionChannel();
+    }
+
+    private void initPrometheusScraper(OptionHolder optionHolder, ConfigReader configReader,
+                                       SourceEventListener sourceEventListener, SiddhiAppContext siddhiAppContext) {
+
+        this.targetURL = optionHolder.validateAndGetStaticValue(PrometheusConstants.TARGET_URL,
+                configReader.readConfig(PrometheusConstants.TARGET_URL_CONFIGURATION, EMPTY_STRING));
+        this.scheme = optionHolder.validateAndGetStaticValue(PrometheusConstants.SCHEME, configReader
+                .readConfig(PrometheusConstants.SCHEME_CONFIGURATION, PrometheusConstants.HTTP_SCHEME));
+        if (!(scheme.equalsIgnoreCase(PrometheusConstants.HTTP_SCHEME) || scheme.equalsIgnoreCase(
+                PrometheusConstants.HTTPS_SCHEME))) {
+            throw new SiddhiAppCreationException("The field \'scheme\' contains unsupported value \'" + scheme + "\' " +
+                    "in " + streamName + " of " + PrometheusConstants.PROMETHEUS_SOURCE);
+        }
+        if (PrometheusSourceUtil.checkEmptyString(targetURL)) {
+            throw new SiddhiAppCreationException("The target URL field found empty but it is a Mandatory field of " +
+                    "" + PrometheusConstants.PROMETHEUS_SOURCE + " in " + streamName);
+        }
+        try {
+            URL url = new URL(targetURL);
+            if (!(url.getProtocol()).equalsIgnoreCase(scheme)) {
+                throw new SiddhiAppCreationException("The provided scheme and the scheme of target URL are " +
+                        "not matching in Prometheus source associated with stream " + streamName);
+            }
+        } catch (MalformedURLException e) {
+            throw new SiddhiAppCreationException("The Prometheus source associated with stream " + streamName +
+                    " contains an invalid value \'" + targetURL + "\' for target URL" , e);
+        }
+        scrapeIntervalInSeconds = validateAndSetNumericValue(optionHolder.validateAndGetStaticValue(
+                PrometheusConstants.SCRAPE_INTERVAL, configReader.readConfig(
+                        PrometheusConstants.SCRAPE_INTERVAL_CONFIGURATION,
+                        PrometheusConstants.DEFAULT_SCRAPE_INTERVAL)), PrometheusConstants.SCRAPE_INTERVAL);
+        long scrapeTimeoutInSeconds = validateAndSetNumericValue(optionHolder.validateAndGetStaticValue(
+                PrometheusConstants.SCRAPE_TIMEOUT,
+                configReader.readConfig(PrometheusConstants.SCRAPE_TIMEOUT_CONFIGURATION,
+                        PrometheusConstants.DEFAULT_SCRAPE_TIMEOUT)), PrometheusConstants.SCRAPE_TIMEOUT);
+        String userName = optionHolder.validateAndGetStaticValue(PrometheusConstants.USERNAME_BASIC_AUTH,
+                configReader.readConfig(PrometheusConstants.USERNAME_BASIC_AUTH_CONFIGURATION, EMPTY_STRING));
+        String password = optionHolder.validateAndGetStaticValue(PrometheusConstants.PASSWORD_BASIC_AUTH,
+                configReader.readConfig(PrometheusConstants.PASSWORD_BASIC_AUTH_CONFIGURATION, EMPTY_STRING));
+        String clientStoreFile = optionHolder.validateAndGetStaticValue(PrometheusConstants.TRUSTSTORE_FILE,
+                PrometheusSourceUtil.trustStorePath(configReader));
+        String clientStorePassword = optionHolder.validateAndGetStaticValue(PrometheusConstants.TRUSTSTORE_PASSWORD,
+                PrometheusSourceUtil.trustStorePassword(configReader));
+        String headers = optionHolder.validateAndGetStaticValue(PrometheusConstants.REQUEST_HEADERS,
+                configReader.readConfig(PrometheusConstants.REQUEST_HEADERS_CONFIGURATION, EMPTY_STRING));
+
+        List<Header> headerList = PrometheusSourceUtil.getHeaders(headers, streamName);
+        this.prometheusScraper = new PrometheusScraper(targetURL, scheme, scrapeTimeoutInSeconds, headerList,
+                sourceEventListener, streamName);
+        if ((!PrometheusSourceUtil.checkEmptyString(userName) || !PrometheusSourceUtil.checkEmptyString(password))) {
+            if ((PrometheusSourceUtil.checkEmptyString(userName) || PrometheusSourceUtil.checkEmptyString(password))) {
+                throw new SiddhiAppCreationException("Please provide user name and password in " +
+                        PrometheusConstants.PROMETHEUS_SOURCE + " associated with the stream " + streamName + " in " +
+                        "Siddhi app " + siddhiAppContext.getName());
+            }
+            prometheusScraper.setAuthorizationCredentials(userName, password);
+        }
+
+        if (PrometheusConstants.HTTPS_SCHEME.equalsIgnoreCase(scheme) &&
+                ((PrometheusSourceUtil.checkEmptyString(clientStoreFile)) ||
+                (PrometheusSourceUtil.checkEmptyString(clientStorePassword)))) {
+
+            throw new SiddhiAppCreationException("Client trustStore file path or password are empty while " +
+                    "default scheme is 'https'. Please provide client " +
+                    "trustStore file path and password in " + streamName + " of " +
+                    PrometheusConstants.PROMETHEUS_SOURCE);
+        }
+        if (PrometheusConstants.HTTPS_SCHEME.equalsIgnoreCase(scheme)) {
+            prometheusScraper.setHttpsProperties(clientStoreFile, clientStorePassword);
+        }
+    }
+
+    private long validateAndSetNumericValue(String value, String field) {
+        long number;
+        try {
+            number = Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            throw new SiddhiAppCreationException("Invalid value \'" + value + "\' is found inside the field" +
+                    " \'" + field + "\' from " + PrometheusConstants.PROMETHEUS_SOURCE + " associated with stream \'" +
+                    "" + streamName + "\'. Please provide a valid numeric value.", e);
+        }
+        if (number < 0) {
+            throw new SiddhiAppCreationException("The value \'" + value + "\' of field \'" + field + "\' from " +
+                    PrometheusConstants.PROMETHEUS_SOURCE + " cannot be negative in " + streamName);
+        }
+        return number;
+    }
+
+    private void configureMetricAnalyser(OptionHolder optionHolder, ConfigReader configReader,
+                                         SiddhiAppContext siddhiAppContext) {
+        String metricName = optionHolder.validateAndGetStaticValue(PrometheusConstants.METRIC_NAME, streamName);
+        MetricType metricType = MetricType.assignMetricType(optionHolder.
+                        validateAndGetStaticValue(PrometheusConstants.METRIC_TYPE),
+                streamName);
+        String job = optionHolder.validateAndGetStaticValue(PrometheusConstants.METRIC_JOB,
+                configReader.readConfig(PrometheusConstants.METRIC_JOB_CONFIGURATION, EMPTY_STRING));
+        String instance = optionHolder.validateAndGetStaticValue(PrometheusConstants.METRIC_INSTANCE,
+                configReader.readConfig(PrometheusConstants.METRIC_INSTANCE_CONFIGURATION, EMPTY_STRING));
+        Map<String, String> groupingKeyMap = PrometheusSourceUtil.populateStringMap(
+                optionHolder.validateAndGetStaticValue(PrometheusConstants.METRIC_GROUPING_KEY, EMPTY_STRING),
+                streamName);
+        Attribute.Type valueType;
+        try {
+            valueType = getStreamDefinition().getAttributeType(PrometheusConstants.VALUE_STRING);
+            if (valueType.equals(Attribute.Type.STRING) || valueType.equals(Attribute.Type.BOOL) ||
+                    valueType.equals(Attribute.Type.OBJECT)) {
+                throw new SiddhiAppCreationException("The attribute \'" + PrometheusConstants.VALUE_STRING + "\' " +
+                        "contains unsupported type \'" + valueType.toString() + "\' in " +
+                        PrometheusConstants.PROMETHEUS_SOURCE + " associated with stream \'" + streamName + "\'");
+            }
+        } catch (AttributeNotExistException e) {
+            throw new SiddhiAppCreationException("The value attribute \'" + PrometheusConstants.VALUE_STRING + "\' is" +
+                    " not found in " + PrometheusConstants.PROMETHEUS_SOURCE + " associated with stream \'"
+                    + streamName + "\'", e);
+        }
+
+        prometheusScraper.setMetricProperties(metricName, metricType, job, instance, groupingKeyMap, valueType);
+    }
+
+    @Override
+    public Class[] getOutputEventClasses() {
+        return new Class[]{Map.class};
+    }
+
+    @Override
+    public void connect(ConnectionCallback connectionCallback) throws ConnectionUnavailableException {
+        PrometheusScraper.CompletionCallback completionCallback = (Throwable error) ->
+        {
+            if (error.getClass().equals(ConnectionUnavailableException.class)) {
+                connectionCallback.onError(new ConnectionUnavailableException(
+                        "Connection to the target is lost.", error));
+            } else {
+                destroy();
+                throw new SiddhiAppRuntimeException("Failed while retrieving and analysing the metrics.", error);
+            }
+        };
+        prometheusScraper.setCompletionCallback(completionCallback);
+        executorService.scheduleWithFixedDelay(prometheusScraper, 0, scrapeIntervalInSeconds, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void disconnect() {
+        executorService.shutdown();
+        prometheusScraper.pause();
+        prometheusScraper.clearConnectorFactory();
+    }
+
+    @Override
+    public void destroy() {
+        prometheusScraper.clearPrometheusScraper();
+        prometheusScraper.clearConnectorFactory();
+    }
+
+    @Override
+    public void pause() {
+        prometheusScraper.pause();
+    }
+
+    @Override
+    public void resume() {
+        prometheusScraper.resume();
+    }
+
+    @Override
+    public Map<String, Object> currentState() {
+        Map<String, Object> currentState = new HashMap<>();
+        currentState.put(PrometheusConstants.LAST_RETRIEVED_SAMPLES, prometheusScraper.getLastValidResponse());
+        return currentState;
+    }
+
+    @Override
+    public void restoreState(Map<String, Object> map) {
+        prometheusScraper.setLastValidResponse((List<String>) map.get(PrometheusConstants.LAST_RETRIEVED_SAMPLES));
+
+    }
+
+}
+

--- a/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/source/PrometheusSource.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/source/PrometheusSource.java
@@ -397,13 +397,15 @@ public class PrometheusSource extends Source {
         List<Header> headerList = PrometheusSourceUtil.getHeaders(headers, streamName);
         this.prometheusScraper = new PrometheusScraper(targetURL, scheme, scrapeTimeoutInSeconds, headerList,
                 sourceEventListener, streamName);
-        if ((!PrometheusSourceUtil.checkEmptyString(userName) || !PrometheusSourceUtil.checkEmptyString(password))) {
-            if ((PrometheusSourceUtil.checkEmptyString(userName) || PrometheusSourceUtil.checkEmptyString(password))) {
+        if ((!PrometheusSourceUtil.checkEmptyString(userName) && !PrometheusSourceUtil.checkEmptyString(password))) {
+            prometheusScraper.setAuthorizationCredentials(userName, password);
+        } else {
+            // check if only one parameter in either username or password is provided, then throw exception
+            if (!(PrometheusSourceUtil.checkEmptyString(userName) && PrometheusSourceUtil.checkEmptyString(password))) {
                 throw new SiddhiAppCreationException("Please provide user name and password in " +
                         PrometheusConstants.PROMETHEUS_SOURCE + " associated with the stream " + streamName + " in " +
                         "Siddhi app " + siddhiAppContext.getName());
             }
-            prometheusScraper.setAuthorizationCredentials(userName, password);
         }
 
         if (PrometheusConstants.HTTPS_SCHEME.equalsIgnoreCase(scheme) &&

--- a/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/util/PrometheusConstants.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/util/PrometheusConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/util/PrometheusConstants.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/util/PrometheusConstants.java
@@ -23,6 +23,9 @@ package org.wso2.extension.siddhi.io.prometheus.util;
  */
 public class PrometheusConstants {
 
+    private PrometheusConstants() {
+    }
+
     //Constants for Prometheus-sink
     public static final String JOB_NAME = "job";
     public static final String PUSH_URL = "push.url";

--- a/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/util/PrometheusConstants.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/util/PrometheusConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -23,6 +23,7 @@ package org.wso2.extension.siddhi.io.prometheus.util;
  */
 public class PrometheusConstants {
 
+    //Constants for Prometheus-sink
     public static final String JOB_NAME = "job";
     public static final String PUSH_URL = "push.url";
     public static final String SERVER_URL = "server.url";
@@ -41,10 +42,11 @@ public class PrometheusConstants {
     public static final String HELP_STRING = "help for ";
     public static final String SPACE_STRING = " ";
 
-    public static final String DEFAULT_JOB_NAME = "siddhiJob";
-    public static final String DEFAULT_PUBLISH_MODE = "server";
-    public static final String DEFAULT_PUSH_URL = "http://localhost:9091";
-    public static final String DEFAULT_SERVER_URL = "http://localhost:9080";
+    //Default values for Prometheus-sink
+    static final String DEFAULT_JOB_NAME = "siddhiJob";
+    static final String DEFAULT_PUBLISH_MODE = "server";
+    static final String DEFAULT_PUSH_URL = "http://localhost:9091";
+    static final String DEFAULT_SERVER_URL = "http://localhost:9080";
     public static final String DEFAULT_ERROR = "0.001";
     public static final String VALUE_STRING = "value";
     public static final String METRIC_NAME_REGEX = "[a-zA-Z_:][a-zA-Z0-9_:]*";
@@ -55,19 +57,80 @@ public class PrometheusConstants {
     public static final String PUSH_OPERATION = "push";
     public static final String PUSH_ADD_OPERATION = "pushadd";
 
-    public static final String KEY_VALUE_SEPARATOR = "','";
-    public static final String VALUE_SEPARATOR = ":";
-    public static final String ELEMENT_SEPARATOR = "\\s*,\\s*";
+    static final String KEY_VALUE_SEPARATOR = "','";
+    static final String VALUE_SEPARATOR = ":";
+    static final String ELEMENT_SEPARATOR = "\\s*,\\s*";
 
     public static final String REGISTERED_METRICS = "Last registered sample";
     public static final String MAP_ANNOTATION = "map";
     public static final String PAYLOAD_ANNOTATION = "payload";
 
+    //System parameter names for Prometheus-sink
+    static final String JOB_NAME_CONFIGURATION = "jobName";
+    static final String PUSH_URL_CONFIGURATION = "pushURL";
+    static final String SERVER_URL_CONFIGURATION = "serverURL";
+    static final String PUBLISH_MODE_CONFIGURATION = "publishMode";
+    static final String GROUPING_KEY_CONFIGURATION = "groupingKey";
 
-    public static final String JOB_NAME_CONFIGURATION = "jobName";
-    public static final String PUSH_URL_CONFIGURATION = "pushURL";
-    public static final String SERVER_URL_CONFIGURATION = "serverURL";
-    public static final String PUBLISH_MODE_CONFIGURATION = "publishMode";
-    public static final String GROUPING_KEY_CONFIGURATION = "groupingKey";
+    //Constants for Prometheus-source
+    public static final String TARGET_URL = "target.url";
+    public static final String SCRAPE_INTERVAL = "scrape.interval";
+    public static final String SCRAPE_TIMEOUT = "scrape.timeout";
+    public static final String SCHEME = "scheme";
+    public static final String USERNAME_BASIC_AUTH = "username";
+    public static final String PASSWORD_BASIC_AUTH = "password";
+    public static final String TRUSTSTORE_FILE = "client.truststore.file";
+    public static final String TRUSTSTORE_PASSWORD = "client.truststore.password";
+    public static final String REQUEST_HEADERS = "headers";
+    public static final String METRIC_JOB = "job";
+    public static final String METRIC_INSTANCE = "instance";
+    public static final String METRIC_GROUPING_KEY = "grouping.key";
 
+    //System parameter names for Prometheus-source
+    public static final String TARGET_URL_CONFIGURATION = "targetURL";
+    public static final String SCRAPE_INTERVAL_CONFIGURATION = "scrapeInterval";
+    public static final String SCRAPE_TIMEOUT_CONFIGURATION = "scrapeTimeout";
+    public static final String SCHEME_CONFIGURATION = "scheme";
+    public static final String USERNAME_BASIC_AUTH_CONFIGURATION = "username";
+    public static final String PASSWORD_BASIC_AUTH_CONFIGURATION = "password";
+    static final String TRUSTSTORE_FILE_CONFIGURATION = "trustStoreFile";
+    static final String TRUSTSTORE_PASSWORD_CONFIGURATION = "trustStorePassword";
+    public static final String REQUEST_HEADERS_CONFIGURATION = "headers";
+    public static final String METRIC_JOB_CONFIGURATION = "job";
+    public static final String METRIC_INSTANCE_CONFIGURATION = "instance";
+
+    public static final String HTTP_SCHEME = "http";
+    public static final String HTTPS_SCHEME = "https";
+
+    //Default values for Prometheus-source
+    public static final String DEFAULT_SCRAPE_INTERVAL = "60";
+    public static final String DEFAULT_SCRAPE_TIMEOUT = "10";
+    public static final String PROMETHEUS_SOURCE = "Prometheus source";
+    static final int DEFAULT_HTTPS_PORT = 443;
+    public static final String DEFAULT_HTTP_METHOD = "GET";
+    static final int DEFAULT_HTTP_PORT = 80;
+    static final String TRUSTSTORE_PATH_VALUE = "${carbon.home}/resources/security/client-truststore.jks";
+    static final String TRUSTSTORE_PASSWORD_VALUE = "wso2carbon";
+    public static final String TEXT_PLAIN = "text/plain";
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String HTTP_CONTENT_TYPE = "Content-Type";
+    public static final String HTTP_METHOD = "HTTP_METHOD";
+
+    //Map keys and values for Prometheus-source
+    public static final String MAP_NAME = "metric_name";
+    public static final String MAP_TYPE = "metric_type";
+    public static final String MAP_HELP = "help";
+    public static final String MAP_SAMPLE_SUBTYPE = "subtype";
+    public static final String MAP_SAMPLE_VALUE = "value";
+    public static final String SUBTYPE_NULL = "null";
+    public static final String SUBTYPE_BUCKET = "bucket";
+    public static final String SUBTYPE_COUNT = "count";
+    public static final String SUBTYPE_SUM = "sum";
+
+    public static final String BUCKET_POSTFIX = "_bucket";
+    public static final String COUNT_POSTFIX = "_count";
+    public static final String SUM_POSTFIX = "_sum";
+    public static final String LAST_RETRIEVED_SAMPLES = "last.retrieved.samples";
+    public static final String LE_KEY = "le";
+    public static final String QUANTILE_KEY = "quantile";
 }

--- a/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/util/PrometheusSinkUtil.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/util/PrometheusSinkUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/util/PrometheusSinkUtil.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/util/PrometheusSinkUtil.java
@@ -168,7 +168,7 @@ public class PrometheusSinkUtil {
      * @param sinkConfigReader configuration reader for sink.
      * @return default job name.
      */
-    public static String jobName(ConfigReader sinkConfigReader) {
+    public static String configureJobName(ConfigReader sinkConfigReader) {
         return sinkConfigReader.readConfig(PrometheusConstants.JOB_NAME_CONFIGURATION,
                 PrometheusConstants.DEFAULT_JOB_NAME);
     }
@@ -180,7 +180,7 @@ public class PrometheusSinkUtil {
      * @param sinkConfigReader configuration reader for sink.
      * @return default push gateway URL.
      */
-    public static String pushURL(ConfigReader sinkConfigReader) {
+    public static String configurePushURL(ConfigReader sinkConfigReader) {
         return sinkConfigReader.readConfig(PrometheusConstants.PUSH_URL_CONFIGURATION,
                 PrometheusConstants.DEFAULT_PUSH_URL);
     }
@@ -192,7 +192,7 @@ public class PrometheusSinkUtil {
      * @param sinkConfigReader configuration reader for sink.
      * @return default server URL.
      */
-    public static String serverURL(ConfigReader sinkConfigReader) {
+    public static String configureServerURL(ConfigReader sinkConfigReader) {
         return sinkConfigReader.readConfig(PrometheusConstants.SERVER_URL_CONFIGURATION,
                 PrometheusConstants.DEFAULT_SERVER_URL);
     }
@@ -204,7 +204,7 @@ public class PrometheusSinkUtil {
      * @param sinkConfigReader configuration reader for sink.
      * @return default publish mode.
      */
-    public static String publishMode(ConfigReader sinkConfigReader) {
+    public static String configurePublishMode(ConfigReader sinkConfigReader) {
         return sinkConfigReader.readConfig(PrometheusConstants.PUBLISH_MODE_CONFIGURATION,
                 PrometheusConstants.DEFAULT_PUBLISH_MODE);
     }
@@ -216,7 +216,7 @@ public class PrometheusSinkUtil {
      * @param sinkConfigReader configuration reader for sink.
      * @return default grouping key.
      */
-    public static String groupinKey(ConfigReader sinkConfigReader) {
+    public static String configureGroupinKey(ConfigReader sinkConfigReader) {
         return sinkConfigReader.readConfig(PrometheusConstants.GROUPING_KEY_CONFIGURATION,
                 PrometheusConstants.EMPTY_STRING);
     }

--- a/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/util/PrometheusSinkUtil.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/util/PrometheusSinkUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -34,16 +34,17 @@ import static org.wso2.extension.siddhi.io.prometheus.util.PrometheusConstants.V
 
 
 /**
- * {@code PrometheusUtil } responsible for Prometheus util functions.
+ * {@code PrometheusSinkUtil } responsible for util functions of Prometheus-sink.
  */
 
-public class PrometheusUtil {
+public class PrometheusSinkUtil {
 
 
     /**
      * Split values by ',' for buckets and quantiles definition.
      *
      * @param inputString string input from sink definition
+     * @param streamID    streamId of the stream for error message
      * @return value list as double array
      */
     public static double[] convertToDoubleArray(String inputString, String streamID) {
@@ -66,6 +67,7 @@ public class PrometheusUtil {
      * Validate quantile values to be in between 0 and 1 for summary metric type.
      *
      * @param quantiles quantile values as double array
+     * @param streamID  streamId of the stream for error message
      */
     public static boolean validateQuantiles(double[] quantiles, String streamID) {
         for (double value : quantiles) {
@@ -82,6 +84,7 @@ public class PrometheusUtil {
      * Assign metric types according to sink definition.
      *
      * @param metricTypeString value of metric type parameter from sink definition
+     * @param streamID         streamId of the stream for error message
      * @return Metric type from Prometheus Collector
      */
     public static Collector.Type assignMetricType(String metricTypeString, String streamID) {
@@ -115,26 +118,26 @@ public class PrometheusUtil {
      * Retrieve grouping key of a metric as key-value pair.
      *
      * @param groupingKeyString grouping key parameter as string
+     * @param streamID          streamId of the stream for error message
      * @return key-value pairs of the grouping key as java string map
      */
     public static Map<String, String> populateGroupingKey(String groupingKeyString, String streamID) {
         Map<String, String> groupingKey = new HashMap<>();
-        if (!PrometheusConstants.EMPTY_STRING.equals(groupingKeyString)) {
-            String[] keyList = groupingKeyString.substring(1, groupingKeyString.length() - 1)
-                    .split(KEY_VALUE_SEPARATOR);
-            Arrays.stream(keyList).forEach(valueEntry -> {
-                String[] entry = valueEntry.split(VALUE_SEPARATOR);
-                if (entry.length == 2) {
-                    String key = entry[0];
-                    String value = entry[1];
-                    groupingKey.put(key, value);
-                } else {
-                    throw new SiddhiAppCreationException("The grouping key field in Prometheus sink associated " +
-                            "with the stream \'" + streamID + "\' is not in the expected format. " +
-                            "please insert them as 'key1:val1','key2:val2'.");
-                }
-            });
+        if (PrometheusConstants.EMPTY_STRING.equals(groupingKeyString)) {
+            return groupingKey;
         }
+        String[] keyList = groupingKeyString.substring(1, groupingKeyString.length() - 1)
+                .split(KEY_VALUE_SEPARATOR);
+        Arrays.stream(keyList).forEach(valueEntry -> {
+            String[] entry = valueEntry.split(VALUE_SEPARATOR);
+            if (entry.length != 2) {
+                throw new SiddhiAppCreationException("The grouping key field in Prometheus sink associated " +
+                        "with the stream \'" + streamID + "\' is not in the expected format. " +
+                        "please insert them as 'key1:val1','key2:val2'.");
+            }
+            groupingKey.put(entry[0], entry[1]);
+
+        });
         return groupingKey;
     }
 
@@ -160,58 +163,88 @@ public class PrometheusUtil {
 
     /**
      * user can give custom job name if user did not define them. Then system will read
-     * the default values which is in the deployment yaml.     *
-     * @param sinkConfigReader configuration reader for sink.
+     * the default values which is in the deployment yaml.
      *
+     * @param sinkConfigReader configuration reader for sink.
      * @return default job name.
      */
     public static String jobName(ConfigReader sinkConfigReader) {
         return sinkConfigReader.readConfig(PrometheusConstants.JOB_NAME_CONFIGURATION,
                 PrometheusConstants.DEFAULT_JOB_NAME);
     }
+
     /**
      * user can give custom URL for Prometheus push gateway if user did not give them inside sink definition. Then
-     * system will read the default values which is in the deployment yaml.     *
-     * @param sinkConfigReader configuration reader for sink.
+     * system will read the default values which is in the deployment yaml.
      *
+     * @param sinkConfigReader configuration reader for sink.
      * @return default push gateway URL.
      */
     public static String pushURL(ConfigReader sinkConfigReader) {
         return sinkConfigReader.readConfig(PrometheusConstants.PUSH_URL_CONFIGURATION,
                 PrometheusConstants.DEFAULT_PUSH_URL);
     }
+
     /**
      * user can give custom server URL if user did not give them inside sink definition. Then system will read
-     * the default values which is in the deployment yaml.     *
-     * @param sinkConfigReader configuration reader for sink.
+     * the default values which is in the deployment yaml.
      *
+     * @param sinkConfigReader configuration reader for sink.
      * @return default server URL.
      */
     public static String serverURL(ConfigReader sinkConfigReader) {
         return sinkConfigReader.readConfig(PrometheusConstants.SERVER_URL_CONFIGURATION,
                 PrometheusConstants.DEFAULT_SERVER_URL);
     }
+
     /**
      * user can give custom publish mode if the user did not give them inside sink definition then system read
      * the default values which is in the deployment yaml.
      *
      * @param sinkConfigReader configuration reader for sink.
-     *
      * @return default publish mode.
      */
     public static String publishMode(ConfigReader sinkConfigReader) {
         return sinkConfigReader.readConfig(PrometheusConstants.PUBLISH_MODE_CONFIGURATION,
                 PrometheusConstants.DEFAULT_PUBLISH_MODE);
     }
+
     /**
      * user can give custom grouping key in key-value pairs, if user did not give them inside sink definition.
-     * Then system will read the default values which is in the deployment yaml.     *
-     * @param sinkConfigReader configuration reader for sink.
+     * Then system will read the default values which is in the deployment yaml.
      *
+     * @param sinkConfigReader configuration reader for sink.
      * @return default grouping key.
      */
     public static String groupinKey(ConfigReader sinkConfigReader) {
         return sinkConfigReader.readConfig(PrometheusConstants.GROUPING_KEY_CONFIGURATION,
                 PrometheusConstants.EMPTY_STRING);
+    }
+
+    /**
+     * To retrieve the name of the metric type in String from {@code Collector.Type}
+     *
+     * @param metricType metric type from {@code Collector.Type}
+     * @return name of the metric type
+     */
+    public static String getMetricTypeString(Collector.Type metricType) {
+        switch (metricType) {
+            case COUNTER: {
+                return "counter";
+            }
+            case GAUGE: {
+                return "gauge";
+            }
+            case HISTOGRAM: {
+                return "histogram";
+            }
+            case SUMMARY: {
+                return "summary";
+            }
+            default: {
+                return null;
+                // default will never be executed
+            }
+        }
     }
 }

--- a/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/util/PrometheusSourceUtil.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/util/PrometheusSourceUtil.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.extension.siddhi.io.prometheus.util;
+
+import org.wso2.carbon.messaging.Header;
+import org.wso2.siddhi.core.exception.SiddhiAppCreationException;
+import org.wso2.siddhi.core.util.config.ConfigReader;
+import org.wso2.transport.http.netty.common.Constants;
+import org.wso2.transport.http.netty.config.SenderConfiguration;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * {@code PrometheusSourceUtil } responsible for util functions of Prometheus-source.
+ */
+public class PrometheusSourceUtil {
+
+    public static boolean checkEmptyString(String stringValue) {
+        return PrometheusConstants.EMPTY_STRING.equals(stringValue.trim());
+    }
+
+    public static Map<String, String> getURLProperties(String target, String scheme) throws MalformedURLException {
+        URL targetURL = new URL(target);
+        Map<String, String> httpURLProperties;
+        httpURLProperties = new HashMap<>();
+        httpURLProperties.put(Constants.TO, targetURL.getFile());
+        String protocol = targetURL.getProtocol();
+        httpURLProperties.put(Constants.PROTOCOL, protocol);
+        httpURLProperties.put(Constants.HTTP_HOST, targetURL.getHost());
+        int port;
+        if (Constants.HTTPS_SCHEME.equalsIgnoreCase(protocol)) {
+            port = targetURL.getPort() != -1 ? targetURL.getPort() : PrometheusConstants.DEFAULT_HTTPS_PORT;
+        } else {
+            port = targetURL.getPort() != -1 ? targetURL.getPort() : PrometheusConstants.DEFAULT_HTTP_PORT;
+        }
+        httpURLProperties.put(Constants.HTTP_PORT, Integer.toString(port));
+        httpURLProperties.put(Constants.REQUEST_URL, targetURL.toString());
+        return httpURLProperties;
+    }
+
+    public static String trustStorePath(ConfigReader configReader) {
+        return configReader.readConfig(PrometheusConstants.TRUSTSTORE_FILE_CONFIGURATION,
+                PrometheusConstants.TRUSTSTORE_PATH_VALUE);
+    }
+
+    public static String trustStorePassword(ConfigReader configReader) {
+        return configReader.readConfig(PrometheusConstants.TRUSTSTORE_PASSWORD_CONFIGURATION,
+                PrometheusConstants.TRUSTSTORE_PASSWORD_VALUE);
+    }
+
+    public static SenderConfiguration getSenderConfigurations(Map<String, String> urlProperties, String clientStoreFile,
+                                                              String clientStorePass) {
+        SenderConfiguration httpSender = new SenderConfiguration(urlProperties
+                .get(Constants.HTTP_PORT));
+        if (urlProperties.get(Constants.PROTOCOL).equals(PrometheusConstants.HTTPS_SCHEME)) {
+            httpSender.setTrustStoreFile(clientStoreFile);
+            httpSender.setTrustStorePass(clientStorePass);
+            httpSender.setId(urlProperties.get(Constants.TO));
+        }
+        httpSender.setScheme(urlProperties.get(Constants.PROTOCOL));
+        return httpSender;
+    }
+
+    /**
+     * Method is responsible of to convert string of headers to list of headers.
+     * Example header format : 'name1:value1','name2:value2'
+     *
+     * @param headers string of headers list.
+     * @return list of headers.
+     */
+    public static List<Header> getHeaders(String headers, String streamID) {
+        if (PrometheusSourceUtil.checkEmptyString(headers)) {
+            return null;
+        }
+        List<Header> headersList = new ArrayList<>();
+        String[] headerArray = headers.trim().split(PrometheusConstants.KEY_VALUE_SEPARATOR);
+        for (String headerValue : headerArray) {
+            headerValue = headerValue.substring(1, headerValue.length() - 1);
+            String[] header = headerValue.split(PrometheusConstants.VALUE_SEPARATOR, 2);
+            if (header.length <= 1) {
+                throw new SiddhiAppCreationException(
+                        "Invalid header format found in " + PrometheusConstants.PROMETHEUS_SOURCE + " " +
+                                "associated with stream \'" + streamID + "\'. Please include them as " +
+                                "'key1:value1', 'key2:value2',..");
+            }
+            headersList.add(new Header(header[0], header[1]));
+        }
+        return headersList;
+    }
+
+    /**
+     * Method is responsible of to convert string of key value pairs to map of Strings.
+     * Example input format : 'name1:value1','name2:value2'
+     *
+     * @param stringInput string of key value pairs.
+     * @return map of stringInput.
+     */
+    public static Map<String, String> populateStringMap(String stringInput, String streamName) {
+        Map<String, String> stringMap = new HashMap<>();
+        if (PrometheusSourceUtil.checkEmptyString(stringInput)) {
+            return stringMap;
+        }
+        String[] stringArray = stringInput.trim().split(PrometheusConstants.KEY_VALUE_SEPARATOR);
+        Arrays.stream(stringArray).forEach(valueEntry -> {
+            String[] entry =
+                    valueEntry.substring(1, valueEntry.length() - 1).split(PrometheusConstants.VALUE_SEPARATOR, 2);
+            if (entry.length != 2) {
+                throw new SiddhiAppCreationException(
+                        "Invalid format for key-value input in " + streamName + " of " +
+                                PrometheusConstants.PROMETHEUS_SOURCE + ". Please include as " +
+                                "'key1:value1','key2:value2',..");
+            }
+            stringMap.put(entry[0], entry[1]);
+        });
+        return stringMap;
+    }
+}

--- a/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/util/PrometheusSourceUtil.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/util/PrometheusSourceUtil.java
@@ -43,8 +43,7 @@ public class PrometheusSourceUtil {
 
     public static Map<String, String> getURLProperties(String target, String scheme) throws MalformedURLException {
         URL targetURL = new URL(target);
-        Map<String, String> httpURLProperties;
-        httpURLProperties = new HashMap<>();
+        Map<String, String> httpURLProperties = new HashMap<>();
         httpURLProperties.put(Constants.TO, targetURL.getFile());
         String protocol = targetURL.getProtocol();
         httpURLProperties.put(Constants.PROTOCOL, protocol);

--- a/component/src/main/resources/log4j.properties
+++ b/component/src/main/resources/log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+# Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 #
 # WSO2 Inc. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except

--- a/component/src/main/resources/log4j.properties
+++ b/component/src/main/resources/log4j.properties
@@ -27,5 +27,10 @@
 log4j.rootLogger=INFO, stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%m%n
-#log4j.appender.stdout.layout.ConversionPattern=[%t] %-5p %c %x - %m%n
+log4j.appender.stdout.layout.ConversionPattern=[%t] %-5p %c %x - %m%n
+log4j.logger.org.apache.zookeeper=ERROR, stdout
+log4j.logger.kafka.consumer=ERROR, stdout
+log4j.logger.kafka.utils=ERROR, stdout
+log4j.logger.org.I0Itec.zkclient=ERROR, stdout
+log4j.logger.org.apache.zookeeper.ZooKeeper=ERROR, stdout
+log4j.logger.kafka.producer=ERROR, stdout

--- a/component/src/main/resources/log4j.properties
+++ b/component/src/main/resources/log4j.properties
@@ -1,3 +1,20 @@
+#
+# Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 # For the general syntax of property based configuration files see the
 # documenation of org.apache.log4j.PropertyConfigurator.
 # The root category uses the appender called A1. Since no priority is

--- a/component/src/test/java/org/wso2/extension/siddhi/io/prometheus/sink/PrometheusSinkTest.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/io/prometheus/sink/PrometheusSinkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/component/src/test/java/org/wso2/extension/siddhi/io/prometheus/sink/PrometheusSinkTest.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/io/prometheus/sink/PrometheusSinkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -15,6 +15,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.wso2.extension.siddhi.io.prometheus.sink;
 
 import org.apache.log4j.Logger;
@@ -41,6 +42,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -52,23 +54,23 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Test cases for prometheus sink in server and pushgateway publish mode.
+ * Test cases for prometheus sink in server and pushgateway publish modes.
  * Prometheus server and pushgateway must be up and running for the testcases to pass.
  * Targets must be configured inside the Prometheus configuration file (prometheus.yml) as,
  * - job_name: 'server'
  * honor_labels: true
  * static_configs:
  * - targets: ['localhost:9080']
- *
+ * <p>
  * - job_name: 'pushgateway'
  * honor_labels: true
  * static_configs:
  * - targets: ['localhost:9091']
- *
+ * <p>
  * - job_name: 'configurationTest'
- *   honor_labels: true
- *   static_configs:
- *   - targets: ['localhost:9096']
+ * honor_labels: true
+ * static_configs:
+ * - targets: ['localhost:9096']
  */
 public class PrometheusSinkTest {
 
@@ -92,7 +94,7 @@ public class PrometheusSinkTest {
         serverURL = "http://" + host + ":" + serverPort;
         prometheusServerURL = "http://" + host + ":" + prometheusPort + "/api/v1/query?query=";
         executorService = Executors.newFixedThreadPool(5);
-        log.info("== Prometheus connection tests started ==");
+        log.info("== Prometheus sink tests started ==");
     }
 
     @AfterClass
@@ -101,7 +103,7 @@ public class PrometheusSinkTest {
             executorService.shutdown();
         }
         Thread.sleep(100);
-        log.info("== Prometheus connection tests completed ==");
+        log.info("== Prometheus sink tests completed ==");
     }
 
     @BeforeMethod
@@ -110,6 +112,7 @@ public class PrometheusSinkTest {
         eventArrived.set(false);
         createdEvents.clear();
     }
+
     private void getAndValidateMetrics(String metricName) {
 
         String requestURL = prometheusServerURL + metricName;
@@ -125,7 +128,7 @@ public class PrometheusSinkTest {
             } else {
                 String inputLine;
                 BufferedReader reader = new BufferedReader(
-                        new InputStreamReader(conn.getInputStream()));
+                        new InputStreamReader(conn.getInputStream(), Charset.defaultCharset()));
                 while ((inputLine = reader.readLine()) != null) {
                     response.append(inputLine);
                 }
@@ -266,7 +269,7 @@ public class PrometheusSinkTest {
         inputEvents.add(inputEvent1);
         inputEvents.add(inputEvent2);
         Assert.assertTrue(eventArrived.get());
-        Thread.sleep(1000);
+        Thread.sleep(2000);
         getAndValidateMetrics("testing_metrics");
 
         if (SiddhiTestHelper.isEventsMatch(inputEvents, createdEvents)) {
@@ -580,6 +583,4 @@ public class PrometheusSinkTest {
         prometheusRecoveryApp.shutdown();
         Thread.sleep(100);
     }
-
-
 }

--- a/component/src/test/java/org/wso2/extension/siddhi/io/prometheus/sink/SinkTestWithDocker.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/io/prometheus/sink/SinkTestWithDocker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/component/src/test/java/org/wso2/extension/siddhi/io/prometheus/sink/SinkTestWithDocker.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/io/prometheus/sink/SinkTestWithDocker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -15,6 +15,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.wso2.extension.siddhi.io.prometheus.sink;
 
 import org.apache.log4j.Logger;
@@ -40,6 +41,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -116,7 +118,7 @@ public class SinkTestWithDocker {
             } else {
                 String inputLine;
                 BufferedReader reader = new BufferedReader(
-                        new InputStreamReader(conn.getInputStream()));
+                        new InputStreamReader(conn.getInputStream(), Charset.defaultCharset()));
                 while ((inputLine = reader.readLine()) != null) {
                     response.append(inputLine);
                 }

--- a/component/src/test/java/org/wso2/extension/siddhi/io/prometheus/sink/SinkValidationTestcase.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/io/prometheus/sink/SinkValidationTestcase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/component/src/test/java/org/wso2/extension/siddhi/io/prometheus/sink/SinkValidationTestcase.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/io/prometheus/sink/SinkValidationTestcase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -24,13 +24,12 @@ import org.testng.annotations.Test;
 import org.wso2.siddhi.core.SiddhiAppRuntime;
 import org.wso2.siddhi.core.SiddhiManager;
 import org.wso2.siddhi.core.exception.SiddhiAppCreationException;
-import org.wso2.siddhi.core.stream.input.InputHandler;
 
 /**
  * Test cases for invalid sink definitions.
  */
-public class ValidationTestcase {
-    private static final Logger log = Logger.getLogger(ValidationTestcase.class);
+public class SinkValidationTestcase {
+    private static final Logger log = Logger.getLogger(SinkValidationTestcase.class);
     private static String pushgatewayURL;
     private static String serverURL;
     private static String buckets;
@@ -40,7 +39,7 @@ public class ValidationTestcase {
 
     @BeforeClass
     public static void startTest() {
-        log.info("== Prometheus connection tests started ==");
+        log.info("== Prometheus sink validation tests started ==");
         pushgatewayURL = "http://localhost:9095";
         serverURL = "http://localhost:9096";
         buckets = "2, 4, 6, 8";
@@ -50,7 +49,7 @@ public class ValidationTestcase {
     @AfterClass
     public static void shutdown() throws InterruptedException {
         Thread.sleep(100);
-        log.info("== Prometheus connection tests completed ==");
+        log.info("== Prometheus sink validation tests completed ==");
     }
 
 
@@ -63,7 +62,6 @@ public class ValidationTestcase {
                         + "insert into SinkTestStream;"
         );
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streamDefinition + query);
-        InputHandler inputStream = siddhiAppRuntime.getInputHandler("InputStream");
         siddhiAppRuntime.start();
     }
 
@@ -77,8 +75,6 @@ public class ValidationTestcase {
             expectedExceptionsMessageRegExp = ERROR_MESSAGE +
                     "Custom mapping associated with stream \'(.*)\' is not supported by Prometheus sink")
     public void prometheusValidationTest1() throws InterruptedException {
-        SiddhiManager siddhiManager = new SiddhiManager();
-
 
         log.info("----------------------------------------------------------------------------------");
         log.info("Prometheus Sink test with custom mapping");
@@ -98,8 +94,6 @@ public class ValidationTestcase {
             expectedExceptionsMessageRegExp = ERROR_MESSAGE + "Invalid publish mode : (.*) in Prometheus sink " +
                     "associated with stream \'(.*)\'.")
     public void prometheusValidationTest2() throws InterruptedException {
-        SiddhiManager siddhiManager = new SiddhiManager();
-
 
         log.info("----------------------------------------------------------------------------------");
         log.info("Prometheus Sink test with undefined publish mode");
@@ -121,7 +115,6 @@ public class ValidationTestcase {
             expectedExceptionsMessageRegExp = ERROR_MESSAGE + "The \'metric.type\' field in Prometheus sink " +
                     "associated with stream \'(.*)\' contains illegal value")
     public void prometheusValidationTest3() throws InterruptedException {
-        SiddhiManager siddhiManager = new SiddhiManager();
 
         log.info("----------------------------------------------------------------------------------");
         log.info("Prometheus Sink test with undefined metric type");
@@ -142,7 +135,6 @@ public class ValidationTestcase {
             expectedExceptionsMessageRegExp = ERROR_MESSAGE + "The buckets field in Prometheus sink associated with " +
                     "stream \'(.*)\' is not supported for metric type \'(.*)\'.")
     public void prometheusValidationTest4() throws InterruptedException {
-        SiddhiManager siddhiManager = new SiddhiManager();
 
         log.info("----------------------------------------------------------------------------------");
         log.info("Prometheus Sink test with unsupported metric type with buckets");
@@ -164,7 +156,6 @@ public class ValidationTestcase {
                     "associated with the stream \'(.*)\' is not in the expected format. " +
                     "please insert the numerical values as \"2,3,4,5\".")
     public void prometheusValidationTest5() throws InterruptedException {
-        SiddhiManager siddhiManager = new SiddhiManager();
 
         log.info("----------------------------------------------------------------------------------");
         log.info("Prometheus Sink test with unsupported values for buckets");
@@ -183,7 +174,6 @@ public class ValidationTestcase {
             expectedExceptionsMessageRegExp = ERROR_MESSAGE + "The quantiles field in Prometheus sink associated " +
                     "with stream \'(.*)\' is not supported for metric type \'(.*)\'.")
     public void prometheusValidationTest6() throws InterruptedException {
-        SiddhiManager siddhiManager = new SiddhiManager();
 
         log.info("----------------------------------------------------------------------------------");
         log.info("Prometheus Sink test with unsupported metric type for quantiles");
@@ -204,7 +194,6 @@ public class ValidationTestcase {
                     "sink associated with stream \'(.*)\' are invalid." +
                     "Please insert values between 0 and 1.")
     public void prometheusValidationTest7() throws InterruptedException {
-        SiddhiManager siddhiManager = new SiddhiManager();
 
         log.info("----------------------------------------------------------------------------------");
         log.info("Prometheus Sink test with unsupported values for quantiles");
@@ -222,10 +211,8 @@ public class ValidationTestcase {
 
     @Test(expectedExceptions = SiddhiAppCreationException.class,
             expectedExceptionsMessageRegExp = ERROR_MESSAGE + "Metric name \'(.*)\' does not match the regex " +
-                    "\"(.*)\" in Prometheus sink associated with stream \'(.*)\'."
-    )
+                    "\"(.*)\" in Prometheus sink associated with stream \'(.*)\'.")
     public void prometheusValidationTest8() throws InterruptedException {
-        SiddhiManager siddhiManager = new SiddhiManager();
 
         log.info("----------------------------------------------------------------------------------");
         log.info("Prometheus Sink test with user defined metric name in unsupported format");
@@ -246,7 +233,6 @@ public class ValidationTestcase {
             expectedExceptionsMessageRegExp = ERROR_MESSAGE + "The value attribute (.*) is not found " +
                     "in Prometheus sink associated with stream \'(.*)\'")
     public void prometheusValidationTest9() throws InterruptedException {
-        SiddhiManager siddhiManager = new SiddhiManager();
 
         log.info("----------------------------------------------------------------------------------");
         log.info("Prometheus Sink test without value attribute configuration or" +
@@ -268,7 +254,6 @@ public class ValidationTestcase {
             expectedExceptionsMessageRegExp = ERROR_MESSAGE + "The field value attribute \'(.*)\'contains " +
                     "unsupported type in Prometheus sink associated with stream \'(.*)\'")
     public void prometheusValidationTest10() throws InterruptedException {
-        SiddhiManager siddhiManager = new SiddhiManager();
 
         log.info("----------------------------------------------------------------------------------");
         log.info("Prometheus Sink test without value attribute in unsupported type");
@@ -287,8 +272,6 @@ public class ValidationTestcase {
             expectedExceptionsMessageRegExp = ERROR_MESSAGE + "Invalid value for push operation : (.*) in Prometheus" +
                     " sink associated with stream \'(.*)\'.")
     public void prometheusValidationTest11() throws InterruptedException {
-        SiddhiManager siddhiManager = new SiddhiManager();
-
 
         log.info("----------------------------------------------------------------------------------");
         log.info("Prometheus Sink test with invalid value for push operation");
@@ -311,7 +294,6 @@ public class ValidationTestcase {
                     "with the stream \'(.*)\' is not in the expected format. " +
                     "please insert them as 'key1:val1','key2:val2'.")
     public void prometheusValidationTest12() throws InterruptedException {
-        SiddhiManager siddhiManager = new SiddhiManager();
 
         log.info("----------------------------------------------------------------------------------");
         log.info("Prometheus Sink test with grouping key configuration in unsupported format");

--- a/component/src/test/java/org/wso2/extension/siddhi/io/prometheus/sink/SinkValidationTestcase.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/io/prometheus/sink/SinkValidationTestcase.java
@@ -21,7 +21,6 @@ import org.apache.log4j.Logger;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import org.wso2.siddhi.core.SiddhiAppRuntime;
 import org.wso2.siddhi.core.SiddhiManager;
 import org.wso2.siddhi.core.exception.SiddhiAppCreationException;
 
@@ -53,7 +52,7 @@ public class SinkValidationTestcase {
     }
 
 
-    private void startSiddhiApp(String streamDefinition) {
+    private void createSiddhiApp(String streamDefinition) {
         SiddhiManager siddhiManager = new SiddhiManager();
         String query = (
                 "@info(name = 'query') "
@@ -61,8 +60,7 @@ public class SinkValidationTestcase {
                         + "select symbol, value "
                         + "insert into SinkTestStream;"
         );
-        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streamDefinition + query);
-        siddhiAppRuntime.start();
+        siddhiManager.createSiddhiAppRuntime(streamDefinition + query);
     }
 
 
@@ -87,7 +85,7 @@ public class SinkValidationTestcase {
                         "metric.help= 'Metric definition test', " +
                         "@map(type = \'keyvalue\', @payload(mode = 'mode', value = 'value')))" +
                         "Define stream SinkTestStream (symbol String, value int);";
-        startSiddhiApp(streamDefinition1);
+        createSiddhiApp(streamDefinition1);
     }
 
     @Test(expectedExceptions = SiddhiAppCreationException.class,
@@ -108,7 +106,7 @@ public class SinkValidationTestcase {
                 "metric.help= 'Metric type definition test', " +
                 "@map(type = \'keyvalue\'))" +
                 "Define stream SinkTestStream (symbol String, value int, price double);";
-        startSiddhiApp(streamDefinition2);
+        createSiddhiApp(streamDefinition2);
     }
 
     @Test(expectedExceptions = SiddhiAppCreationException.class,
@@ -128,7 +126,7 @@ public class SinkValidationTestcase {
                 "metric.help= 'Metric type definition test', " +
                 "@map(type = \'keyvalue\'))" +
                 "Define stream SinkTestStream (symbol String, value int, price double);";
-        startSiddhiApp(streamDefinition3);
+        createSiddhiApp(streamDefinition3);
     }
 
     @Test(expectedExceptions = SiddhiAppCreationException.class,
@@ -148,7 +146,7 @@ public class SinkValidationTestcase {
                 "@map(type = \'keyvalue\'))" +
                 "Define stream SinkTestStream (symbol String, value int, price double);";
 
-        startSiddhiApp(streamDefinition4);
+        createSiddhiApp(streamDefinition4);
     }
 
     @Test(expectedExceptions = SiddhiAppCreationException.class,
@@ -167,7 +165,7 @@ public class SinkValidationTestcase {
                 "metric.help= 'Metric type definition test', buckets= '2,a,b,3'," +
                 "@map(type = \'keyvalue\'))"
                 + "Define stream MetricTypeTestStream (symbol String, value int, price double);";
-        startSiddhiApp(streamDefinition5);
+        createSiddhiApp(streamDefinition5);
     }
 
     @Test(expectedExceptions = SiddhiAppCreationException.class,
@@ -186,7 +184,7 @@ public class SinkValidationTestcase {
                 "metric.help= 'Metric type definition test', quantiles= '" + quantiles + "'," +
                 "@map(type = \'keyvalue\'))" +
                 "Define stream MetricTypeTestStream (symbol String, value int, price double);";
-        startSiddhiApp(streamDefinition6);
+        createSiddhiApp(streamDefinition6);
     }
 
     @Test(expectedExceptions = SiddhiAppCreationException.class,
@@ -206,7 +204,7 @@ public class SinkValidationTestcase {
                 "metric.help= 'Metric type definition test', quantiles= '0.2,5,2,0.86'," +
                 "@map(type = \'keyvalue\'))"
                 + "Define stream MetricTypeTestStream (symbol String, value int, price double);";
-        startSiddhiApp(streamDefinition7);
+        createSiddhiApp(streamDefinition7);
     }
 
     @Test(expectedExceptions = SiddhiAppCreationException.class,
@@ -226,7 +224,7 @@ public class SinkValidationTestcase {
                 "metric.help= 'Summary definition test', metric.name= '" + metricName + "', " +
                 "quantiles = '" + quantiles + "',@map(type = 'keyvalue'))" +
                 "Define stream SummaryTestStream (symbol String, value int, price double);";
-        startSiddhiApp(streamDefinition8);
+        createSiddhiApp(streamDefinition8);
     }
 
     @Test(expectedExceptions = SiddhiAppCreationException.class,
@@ -247,7 +245,7 @@ public class SinkValidationTestcase {
                 "metric.help= 'Summary definition test', metric.name= 'metric_name_test_value', " +
                 "quantiles = '" + quantiles + "',@map(type = 'keyvalue'))" +
                 "Define stream SummaryTestStream (symbol String, volume int, price double);";
-        startSiddhiApp(streamDefinition9);
+        createSiddhiApp(streamDefinition9);
     }
 
     @Test(expectedExceptions = SiddhiAppCreationException.class,
@@ -265,7 +263,7 @@ public class SinkValidationTestcase {
                 "metric.help= 'Summary definition test', metric.name= 'metric_name_test_summary', " +
                 "quantiles = '" + quantiles + "', @map(type = 'keyvalue'))" +
                 "Define stream SummaryTestStream (symbol String, value string, price double);";
-        startSiddhiApp(streamDefinition10);
+        createSiddhiApp(streamDefinition10);
     }
 
     @Test(expectedExceptions = SiddhiAppCreationException.class,
@@ -286,7 +284,7 @@ public class SinkValidationTestcase {
                 "quantiles = '" + quantiles + "', " +
                 "push.operation = '" + pushOperation + "',@map(type = 'keyvalue'))" +
                 "Define stream SummaryTestStream (symbol String, value int, price double);";
-        startSiddhiApp(streamDefinition11);
+        createSiddhiApp(streamDefinition11);
     }
 
     @Test(expectedExceptions = SiddhiAppCreationException.class,
@@ -307,7 +305,7 @@ public class SinkValidationTestcase {
                 "metric.help= 'Counter definition test'," +
                 "grouping.key = '" + groupingKey + "',@map(type = 'keyvalue'))" +
                 "Define stream SummaryTestStream (symbol String, value int, price double);";
-        startSiddhiApp(streamDefinition12);
+        createSiddhiApp(streamDefinition12);
     }
 }
 

--- a/component/src/test/java/org/wso2/extension/siddhi/io/prometheus/source/PrometheusSourceTest.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/io/prometheus/source/PrometheusSourceTest.java
@@ -1,0 +1,561 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.extension.siddhi.io.prometheus.source;
+
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.Histogram;
+import io.prometheus.client.Summary;
+import io.prometheus.client.exporter.HTTPServer;
+import org.apache.log4j.Logger;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.siddhi.core.SiddhiAppRuntime;
+import org.wso2.siddhi.core.SiddhiManager;
+import org.wso2.siddhi.core.event.Event;
+import org.wso2.siddhi.core.exception.CannotRestoreSiddhiAppStateException;
+import org.wso2.siddhi.core.stream.input.InputHandler;
+import org.wso2.siddhi.core.stream.input.source.Source;
+import org.wso2.siddhi.core.stream.output.StreamCallback;
+import org.wso2.siddhi.core.util.SiddhiTestHelper;
+import org.wso2.siddhi.core.util.config.InMemoryConfigManager;
+import org.wso2.siddhi.core.util.persistence.InMemoryPersistenceStore;
+import org.wso2.siddhi.core.util.persistence.PersistenceStore;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Test cases for the functionality of prometheus source
+ */
+public class PrometheusSourceTest {
+
+    private static final Logger log = Logger.getLogger(PrometheusSourceTest.class);
+    private String targetURL;
+    private HTTPServer server;
+    private String serverPort;
+    private AtomicInteger eventCount = new AtomicInteger(0);
+    private AtomicBoolean eventArrived = new AtomicBoolean(false);
+    private Map<String, ArrayList<Object[]>> eventMap = new HashMap<>();
+    private List<Object[]> receivedEvents = new ArrayList<>();
+
+    @BeforeClass
+    public void startTest() {
+        serverPort = System.getenv("SERVER_PORT");
+        String host = System.getenv("HOST_NAME");
+        log.info("== Prometheus source tests started ==");
+        targetURL = "http://" + host + ":" + serverPort + "/metrics";
+    }
+
+    private void initializeMetrics(int port) {
+        CollectorRegistry registry = new CollectorRegistry();
+        buildMetrics(registry);
+        try {
+            server = new HTTPServer(new InetSocketAddress(port), registry);
+        } catch (IOException e) {
+            log.error("Unable to establish connection at server : " + e);
+        }
+    }
+
+    private void buildMetrics(CollectorRegistry registry) {
+        Counter counter = Counter.build()
+                .name("counter_test")
+                .help("unit test - for counter metric")
+                .labelNames("symbol", "price")
+                .register(registry);
+        counter.labels("WSO2", "78.8").inc(100);
+        counter.labels("IBM", "65.32").inc(125);
+
+        Gauge gauge = Gauge.build()
+                .name("gauge_test")
+                .help("unit test - for gauge metric")
+                .labelNames("symbol", "price")
+                .register(registry);
+        gauge.labels("WSO2", "78.8").inc(100);
+        gauge.labels("IBM", "65.32").inc(125);
+
+        Histogram histogram = Histogram.build()
+                .name("histogram_test")
+                .help("unit test - for histogram metric")
+                .labelNames("symbol", "price")
+                .buckets(50, 70, 90)
+                .register(registry);
+        histogram.labels("WSO2", "78.8").observe(100);
+        histogram.labels("IBM", "65.32").observe(125);
+
+
+        Summary summary = Summary.build()
+                .name("summary_test")
+                .help("unit test - for summary metric")
+                .labelNames("symbol", "price")
+                .quantile(0.25, 0.001)
+                .quantile(0.5, 0.001)
+                .quantile(0.75, 0.001)
+                .quantile(1, 0.0001)
+                .register(registry);
+        summary.labels("WSO2", "78.8").observe(100);
+        summary.labels("IBM", "65.32").observe(125);
+
+    }
+
+    private List<Object[]> retrieveEventList(String metricType) {
+        List<Object[]> eventList = new ArrayList<>();
+        switch (metricType.toUpperCase(Locale.ENGLISH)) {
+            case "COUNTER": {
+                eventList.add(new Object[]{"counter_test", "counter", "unit test - for counter metric", "WSO2",
+                        "78.8", "null", 100});
+                eventList.add(new Object[]{"counter_test", "counter", "unit test - for counter metric", "IBM",
+                        "65.32", "null", 125});
+                break;
+            }
+            case "GAUGE": {
+                eventList.add(new Object[]{"gauge_test", "gauge", "unit test - for gauge metric", "WSO2",
+                        "78.8", "null", 100.0});
+                eventList.add(new Object[]{"gauge_test", "gauge", "unit test - for gauge metric", "IBM",
+                        "65.32", "null", 125.0});
+                break;
+            }
+            default:
+                //default execution is not needed
+        }
+        return eventList;
+    }
+
+    @BeforeMethod
+    public void init() {
+        eventCount.set(0);
+        eventArrived.set(false);
+    }
+
+    @AfterMethod
+    public void endTest() {
+        if (server != null) {
+            server.stop();
+            server = null;
+            log.info("server stopped successfully.");
+        }
+        receivedEvents.clear();
+    }
+
+
+    /**
+     * test for Prometheus source with mandatory fields.
+     *
+     * @throws InterruptedException interrupted exception
+     */
+    @Test(sequential = true)
+    public void prometheusSourceTest1() throws InterruptedException {
+
+        initializeMetrics(Integer.parseInt(serverPort));
+        SiddhiManager siddhiManager = new SiddhiManager();
+        log.info("----------------------------------------------------------------------------------");
+        log.info("Prometheus Source test with mandatory fields.");
+        log.info("----------------------------------------------------------------------------------");
+        String metricType = "counter";
+        String siddhiApp = "@App:name('TestSiddhiApp1')";
+        String sourceStream = "@source(type='prometheus'," +
+                "target.url=\'" + targetURL + "\', " +
+                "scheme = 'http'," +
+                "scrape.interval = '1'," +
+                "scrape.timeout = '5'," +
+                "metric.type='" + metricType + "'," +
+                "metric.name='counter_test'," +
+                "@map(type = 'keyvalue'))" +
+                "Define stream SourceMapTestStream (metric_name String, metric_type String," +
+                " help String, symbol String, price String, subtype String, value int);";
+        String outputStream1 = " @sink(type='log')" +
+                "define stream OutputStream (metric_name String, metric_type String, help String," +
+                " symbol String, price String, subtype String, value int);";
+        String query1 = (
+                "@info(name = 'query1') "
+                        + "from SourceMapTestStream\n" +
+                        "select *\n" +
+                        "insert into OutputStream;"
+        );
+
+        StreamCallback streamCallback = new StreamCallback() {
+            @Override
+            public void receive(Event[] events) {
+                for (Event event : events) {
+                    eventCount.getAndIncrement();
+                    eventArrived.set(true);
+                    receivedEvents.add(event.getData());
+                }
+            }
+        };
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(siddhiApp + sourceStream +
+                outputStream1 + query1);
+        siddhiAppRuntime.addCallback("OutputStream", streamCallback);
+        StreamCallback insertionStreamCallback = new StreamCallback() {
+            @Override
+            public void receive(Event[] events) {
+                for (Event event : events) {
+                    eventArrived.set(true);
+
+                }
+            }
+        };
+        siddhiAppRuntime.addCallback("SourceMapTestStream", insertionStreamCallback);
+        siddhiAppRuntime.start();
+        Thread.sleep(2000);
+
+        if (SiddhiTestHelper.isEventsMatch(receivedEvents, retrieveEventList(metricType))) {
+            Assert.assertEquals(eventCount.get(), 2);
+        } else {
+            Assert.fail("Events does not match");
+        }
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test(sequential = true)
+    public void prometheusSourceTest2() throws Exception {
+        log.info("----------------------------------------------------------------------------------");
+        log.info("Test to verify Prometheus source with custom configuration.");
+        log.info("----------------------------------------------------------------------------------");
+
+        String serverPort = System.getenv("SERVER_CONFIG_PORT");
+        String host = System.getenv("HOST_NAME");
+        String url = "http://" + host + ":" + serverPort;
+        initializeMetrics(Integer.parseInt(serverPort));
+        Map<String, String> serverConfig = new HashMap<>();
+        serverConfig.put("source.prometheus.targetURL", url);
+        serverConfig.put("source.prometheus.scrapeInterval", "5");
+        InMemoryConfigManager configManager = new InMemoryConfigManager(serverConfig, null);
+        configManager.generateConfigReader("source", "prometheus");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        siddhiManager.setConfigManager(configManager);
+
+        String metricType = "gauge";
+        String siddhiApp = "@App:name('TestSiddhiApp2')";
+        String sourceStream = "@source(type='prometheus'," +
+                "scheme = 'http'," +
+                "scrape.timeout = '5'," +
+                "metric.type='" + metricType + "'," +
+                "metric.name='gauge_test'," +
+                "@map(type = 'keyvalue'))" +
+                "Define stream SourceMapTestStream (metric_name String, metric_type String," +
+                " help String, symbol String, price String, subtype String, value double);";
+        String outputStream1 = " @sink(type='log')" +
+                "define stream OutputStream (metric_name String, metric_type String, help String," +
+                " symbol String, price String, subtype String, value double);";
+        String query1 = (
+                "@info(name = 'query1') "
+                        + "from SourceMapTestStream\n" +
+                        "select *\n" +
+                        "insert into OutputStream;"
+        );
+
+        StreamCallback streamCallback = new StreamCallback() {
+            @Override
+            public void receive(Event[] events) {
+                for (Event event : events) {
+                    eventCount.getAndIncrement();
+                    eventArrived.set(true);
+                }
+            }
+        };
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(siddhiApp + sourceStream +
+                outputStream1 + query1);
+        siddhiAppRuntime.addCallback("OutputStream", streamCallback);
+        StreamCallback insertionStreamCallback = new StreamCallback() {
+            @Override
+            public void receive(Event[] events) {
+                for (Event event : events) {
+                    eventArrived.set(true);
+                    receivedEvents.add(event.getData());
+                }
+            }
+        };
+        siddhiAppRuntime.addCallback("SourceMapTestStream", insertionStreamCallback);
+        siddhiAppRuntime.start();
+
+        Thread.sleep(2000);
+
+        if (SiddhiTestHelper.isEventsMatch(receivedEvents, retrieveEventList(metricType))) {
+            Assert.assertEquals(eventCount.get(), 2);
+        } else {
+            Assert.fail("Events does not match");
+        }
+        siddhiAppRuntime.shutdown();
+    }
+
+    /**
+     * test for Prometheus source in pause and resume states.
+     *
+     * @throws InterruptedException
+     **/
+    @Test(sequential = true)
+    public void prometheusSourceTest3() throws InterruptedException, CannotRestoreSiddhiAppStateException {
+
+        log.info("----------------------------------------------------------------------------------");
+        log.info("Test to verify the pause and resume functionality of Prometheus source ");
+        log.info("----------------------------------------------------------------------------------");
+
+        ExecutorService executorService = Executors.newFixedThreadPool(1);
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        siddhiManager.setPersistenceStore(new InMemoryPersistenceStore());
+        String metricType = "histogram";
+        final String sourceStream = "@App:name('prometheusPauseResumeApp') " +
+                "@source(type='prometheus'," +
+                "scheme = 'http'," +
+                "target.url=\'" + targetURL + "\', " +
+                "scrape.interval = '1'," +
+                "scrape.timeout = '5'," +
+                "metric.type='" + metricType + "'," +
+                "metric.name='histogram_test'," +
+                "@map(type = 'keyvalue'))" +
+                "Define stream SourceMapTestStream (metric_name String, metric_type String," +
+                " help String, name String, price String, le String, subtype String, value double);";
+        final String sinkStream = "@sink(type='prometheus'," +
+                "job='sinkTest'," +
+                "metric.help= 'test metric'," +
+                "publish.mode='server'," +
+                "server.url='" + targetURL + "'," +
+                "metric.type='" + metricType + "'," +
+                "buckets='50, 70, 90'," +
+                "metric.name='histogram_test'," +
+                "@map(type = 'keyvalue'))" +
+                "Define stream TestStream (name String, price int, value double);";
+        final String inputStream = "define stream InputStream (name String, price int, value double);\n";
+        final String outputStream = " @sink(type='log')" +
+                "define stream OutputStream (metric_name String, metric_type String, help String," +
+                " name String, price String, le String, subtype String, value double);";
+        String query = "@info(name = 'queryInputToPrometheusSink') \n" +
+                "from InputStream\n" +
+                "select *\n" +
+                "insert into TestStream;\n" +
+                "\n" +
+                "@info(name = 'queryPrometheusSourceToPrometheusSink') \n" +
+                "from SourceMapTestStream\n" +
+                "select *\n" +
+                "insert into OutputStream;\n";
+
+
+        SiddhiAppRuntime prometheusRecoveryApp =
+                siddhiManager.createSiddhiAppRuntime(sourceStream + inputStream + sinkStream + outputStream + query);
+        InputHandler inputHandler = prometheusRecoveryApp.getInputHandler("InputStream");
+        prometheusRecoveryApp.addCallback("OutputStream", new StreamCallback() {
+            @Override
+            public synchronized void receive(Event[] events) {
+                for (Event event : events) {
+                    eventCount.getAndIncrement();
+                    eventArrived.set(true);
+                }
+            }
+        });
+        // Start the apps
+        prometheusRecoveryApp.start();
+        Object[] inputEvent1 = new Object[]{"WSO2", 78.8, 100};
+        Object[] inputEvent2 = new Object[]{"IBM", 65.32, 125};
+
+        // start receiving events
+        Future eventSender = executorService.submit(() -> {
+            try {
+                inputHandler.send(inputEvent1);
+                inputHandler.send(inputEvent2);
+            } catch (InterruptedException e) {
+                log.error(e);
+            }
+        });
+
+        while (!eventSender.isDone()) {
+            Thread.sleep(1000);
+        }
+        Thread.sleep(1000);
+        Assert.assertEquals(eventCount.get(), 12);
+        Assert.assertTrue(eventArrived.get());
+
+        Collection<List<Source>> sources = prometheusRecoveryApp.getSources();
+        // pause the transports
+        sources.forEach(e -> e.forEach(Source::pause));
+
+        init();
+        eventSender = executorService.submit(() -> {
+            try {
+                inputHandler.send(inputEvent1);
+                inputHandler.send(inputEvent2);
+            } catch (InterruptedException e) {
+                log.error(e);
+            }
+        });
+        while (!eventSender.isDone()) {
+            Thread.sleep(1000);
+        }
+
+        Thread.sleep(2000);
+        Assert.assertFalse(eventArrived.get());
+
+        // resume the transports
+        sources.forEach(e -> e.forEach(Source::resume));
+        Thread.sleep(2000);
+        Assert.assertEquals(eventCount.get(), 12);
+        Assert.assertTrue(eventArrived.get());
+        prometheusRecoveryApp.shutdown();
+    }
+
+    @Test(sequential = true)
+    public void prometheusSourceTest4() throws Exception {
+        log.info("----------------------------------------------------------------------------------");
+        log.info("Test to verify the recovering process of a Siddhi node on a failure in Prometheus source .");
+        log.info("----------------------------------------------------------------------------------");
+
+
+        PersistenceStore persistenceStore = new InMemoryPersistenceStore();
+        SiddhiManager siddhiManager = new SiddhiManager();
+        siddhiManager.setPersistenceStore(persistenceStore);
+        String metricType = "histogram";
+        String siddhiApp = "@App:name('prometheusSinkApp') " +
+                "@sink(type='prometheus'," +
+                "job='sinkTest'," +
+                "metric.help= 'test metric'," +
+                "publish.mode='server'," +
+                "server.url='" + targetURL + "'," +
+                "metric.type='" + metricType + "'," +
+                "buckets='50, 70, 90'," +
+                "metric.name='histogram_test'," +
+                "@map(type = 'keyvalue'))" +
+                "Define stream TestStream (name String, price int, value double);" +
+                "define stream InputStream (name String, price int, value double);\n" +
+                " @sink(type='log')" +
+                "from InputStream\n" +
+                "select *\n" +
+                "insert into TestStream;\n";
+        String siddhiApp1 = "@App:name('prometheusRecoveryApp') " +
+                "@source(type='prometheus'," +
+                "scheme = 'http'," +
+                "target.url=\'" + targetURL + "\', " +
+                "scrape.interval = '10'," +
+                "scrape.timeout = '15'," +
+                "metric.type='" + metricType + "'," +
+                "metric.name='histogram_test'," +
+                "@map(type = 'keyvalue'))" +
+                "Define stream SourceMapTestStream (metric_name String, metric_type String," +
+                " help String, name String, price String, le String, subtype String, value double);" +
+                " @sink(type='log')" +
+                "define stream OutputStream (metric_name String, metric_type String, help String," +
+                " name String, price String, le String, subtype String, value double);" +
+                "@info(name = 'queryPrometheusSourceToLog') \n" +
+                "from SourceMapTestStream\n" +
+                "select *\n" +
+                "insert into OutputStream;\n";
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(siddhiApp);
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("InputStream");
+
+        SiddhiAppRuntime siddhiAppRuntime1 = siddhiManager.createSiddhiAppRuntime(siddhiApp1);
+        siddhiAppRuntime1.addCallback("OutputStream", new StreamCallback() {
+            @Override
+            public void receive(Event[] events) {
+                for (Event event : events) {
+                    eventCount.getAndIncrement();
+                    eventArrived.set(true);
+                }
+
+            }
+        });
+        ExecutorService executorService = Executors.newFixedThreadPool(1);
+        Object[] inputEvent1 = new Object[]{"WSO2", 78.8, 100};
+        Object[] inputEvent2 = new Object[]{"IBM", 65.32, 125};
+
+
+        // start publishing events to Prometheus sink
+        Future eventSender = executorService.submit(() -> {
+            try {
+                inputHandler.send(inputEvent1);
+                inputHandler.send(inputEvent2);
+            } catch (InterruptedException e) {
+                log.error(e);
+            }
+        });
+        Thread.sleep(2000);
+        // start the siddhi app
+        siddhiAppRuntime.start();
+        siddhiAppRuntime1.start();
+
+        // wait for some time
+        Thread.sleep(2000);
+        // initiate a checkpointing task
+        Future perisistor = siddhiAppRuntime1.persist().getFuture();
+        // waits till the checkpointing task is done
+        while (!perisistor.isDone()) {
+            Thread.sleep(100);
+        }
+        // let few more events to be published
+        Thread.sleep(2000);
+        Assert.assertTrue(eventArrived.get());
+        // assert the count
+        Assert.assertEquals(12, eventCount.get());
+        // initiate a execution app shutdown - to demonstrate a node failure
+        siddhiAppRuntime1.shutdown();
+
+        // let few events to be published while the execution app is down
+        try {
+            inputHandler.send(inputEvent1);
+            inputHandler.send(inputEvent2);
+        } catch (InterruptedException e) {
+            log.error(e);
+        }
+        Thread.sleep(3000);
+        // recreate the siddhi app
+        siddhiAppRuntime1 = siddhiManager.createSiddhiAppRuntime(siddhiApp1);
+        siddhiAppRuntime1.addCallback("OutputStream", new StreamCallback() {
+            @Override
+            public void receive(Event[] events) {
+                for (Event event : events) {
+                    eventCount.getAndIncrement();
+                    eventArrived.set(true);
+                }
+
+            }
+        });
+        // start the execution app
+        siddhiAppRuntime1.start();
+        // immediately trigger a restore from last revision
+        siddhiAppRuntime1.restoreLastRevision();
+        Thread.sleep(5000);
+
+        // waits till all the events are published
+        while (!eventSender.isDone()) {
+            Thread.sleep(2000);
+        }
+        Thread.sleep(6000);
+        Assert.assertTrue(eventArrived.get());
+        // assert the count
+        Assert.assertEquals(24, eventCount.get());
+        siddhiAppRuntime.shutdown();
+    }
+}
+
+

--- a/component/src/test/java/org/wso2/extension/siddhi/io/prometheus/source/SourceValidationTestcase.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/io/prometheus/source/SourceValidationTestcase.java
@@ -23,10 +23,8 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.extension.siddhi.io.prometheus.util.PrometheusConstants;
-import org.wso2.siddhi.core.SiddhiAppRuntime;
 import org.wso2.siddhi.core.SiddhiManager;
 import org.wso2.siddhi.core.exception.SiddhiAppCreationException;
-import org.wso2.siddhi.core.stream.input.InputHandler;
 
 /**
  * Test cases for invalid source definitions.
@@ -50,7 +48,7 @@ public class SourceValidationTestcase {
     }
 
 
-    private void startSiddhiApp(String streamDefinition) {
+    private void createSiddhiApp(String streamDefinition) {
         SiddhiManager siddhiManager = new SiddhiManager();
         String siddhiApp = "@App:name('TestSiddhiApp')";
         String outputStream = " @sink(type='log', prefix='test')" +
@@ -62,10 +60,7 @@ public class SourceValidationTestcase {
                         + "select * "
                         + "insert into OutputStream;"
         );
-        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(siddhiApp + streamDefinition +
-                outputStream + query);
-        InputHandler inputStream = siddhiAppRuntime.getInputHandler("SourceTestStream");
-        siddhiAppRuntime.start();
+        siddhiManager.createSiddhiAppRuntime(siddhiApp + streamDefinition + outputStream + query);
     }
 
     @Test(expectedExceptions = SiddhiAppCreationException.class,
@@ -87,7 +82,7 @@ public class SourceValidationTestcase {
                 "@map(type = 'keyvalue'))" +
                 "Define stream SourceTestStream (metric_name String, metric_type String, help String, name String," +
                 " age String, subtype String, le String, value double);";
-        startSiddhiApp(sourceStream);
+        createSiddhiApp(sourceStream);
     }
 
     @Test(expectedExceptions = SiddhiAppCreationException.class,
@@ -110,7 +105,7 @@ public class SourceValidationTestcase {
                 "@map(type = 'keyvalue'))" +
                 "Define stream SourceTestStream (metric_name String, metric_type String, help String, name String," +
                 " age String, subtype String, le String, value double);";
-        startSiddhiApp(sourceStream);
+        createSiddhiApp(sourceStream);
     }
 
     @Test(expectedExceptions = SiddhiAppCreationException.class,
@@ -132,7 +127,7 @@ public class SourceValidationTestcase {
                 "@map(type = 'keyvalue'))" +
                 "Define stream SourceTestStream (metric_name String, metric_type String, help String, name String," +
                 " age String, subtype String, le String, value double);";
-        startSiddhiApp(sourceStream);
+        createSiddhiApp(sourceStream);
     }
 
     @Test(expectedExceptions = SiddhiAppCreationException.class,
@@ -155,7 +150,7 @@ public class SourceValidationTestcase {
                 "@map(type = 'keyvalue'))" +
                 "Define stream SourceTestStream (metric_name String, metric_type String, help String, name String," +
                 " age String, subtype String, le String, value double);";
-        startSiddhiApp(sourceStream);
+        createSiddhiApp(sourceStream);
     }
 
     @Test(expectedExceptions = SiddhiAppCreationException.class,
@@ -179,7 +174,7 @@ public class SourceValidationTestcase {
                 "@map(type = 'keyvalue'))" +
                 "Define stream SourceTestStream (metric_name String, metric_type String, help String, name String," +
                 " age String, subtype String, le String, value double);";
-        startSiddhiApp(sourceStream);
+        createSiddhiApp(sourceStream);
     }
 
     @Test(expectedExceptions = SiddhiAppCreationException.class,
@@ -204,7 +199,7 @@ public class SourceValidationTestcase {
                 "@map(type = 'keyvalue'))" +
                 "Define stream SourceTestStream (metric_name String, metric_type String, help String, name String," +
                 " age String, subtype String, le String, value double);";
-        startSiddhiApp(sourceStream);
+        createSiddhiApp(sourceStream);
     }
 
     @Test(expectedExceptions = SiddhiAppCreationException.class,
@@ -228,7 +223,7 @@ public class SourceValidationTestcase {
                 "@map(type = 'keyvalue'))" +
                 "Define stream SourceTestStream (metric_name String, metric_type String, help String, name String," +
                 " age String, subtype String, le String, value double);";
-        startSiddhiApp(sourceStream);
+        createSiddhiApp(sourceStream);
     }
 
     @Test(expectedExceptions = SiddhiAppCreationException.class,
@@ -250,7 +245,7 @@ public class SourceValidationTestcase {
                 "@map(type = 'keyvalue'))" +
                 "Define stream SourceTestStream (metric_name String, metric_type String, help String, name String," +
                 " age String, subtype String, le String, value double);";
-        startSiddhiApp(sourceStream);
+        createSiddhiApp(sourceStream);
     }
 
     @Test(expectedExceptions = SiddhiAppCreationException.class,
@@ -276,7 +271,7 @@ public class SourceValidationTestcase {
                 "@map(type = 'keyvalue'))" +
                 "Define stream SourceTestStream (metric_name String, metric_type String, help String, name String," +
                 " age String, subtype String, le String, value double);";
-        startSiddhiApp(sourceStream);
+        createSiddhiApp(sourceStream);
     }
 
     @Test(expectedExceptions = SiddhiAppCreationException.class,
@@ -298,7 +293,7 @@ public class SourceValidationTestcase {
                 "@map(type = 'keyvalue'))" +
                 "Define stream SourceTestStream (metric_name String, metric_type String, help String, name String," +
                 " age String, subtype String, le String, value double);";
-        startSiddhiApp(sourceStream);
+        createSiddhiApp(sourceStream);
     }
 
     @Test(expectedExceptions = SiddhiAppCreationException.class,
@@ -322,7 +317,7 @@ public class SourceValidationTestcase {
                 "@map(type = 'keyvalue'))" +
                 "Define stream SourceTestStream (metric_name String, metric_type String, help String, name String," +
                 " age String, subtype String, le String);";
-        startSiddhiApp(sourceStream);
+        createSiddhiApp(sourceStream);
     }
 
     @Test(expectedExceptions = SiddhiAppCreationException.class,
@@ -345,6 +340,6 @@ public class SourceValidationTestcase {
                 "@map(type = 'keyvalue'))" +
                 "Define stream SourceTestStream (metric_name String, metric_type String, help String, name String," +
                 " age String, subtype String, le String, value string);";
-        startSiddhiApp(sourceStream);
+        createSiddhiApp(sourceStream);
     }
 }

--- a/component/src/test/java/org/wso2/extension/siddhi/io/prometheus/source/SourceValidationTestcase.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/io/prometheus/source/SourceValidationTestcase.java
@@ -1,0 +1,350 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.extension.siddhi.io.prometheus.source;
+
+import org.apache.log4j.Logger;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.extension.siddhi.io.prometheus.util.PrometheusConstants;
+import org.wso2.siddhi.core.SiddhiAppRuntime;
+import org.wso2.siddhi.core.SiddhiManager;
+import org.wso2.siddhi.core.exception.SiddhiAppCreationException;
+import org.wso2.siddhi.core.stream.input.InputHandler;
+
+/**
+ * Test cases for invalid source definitions.
+ */
+public class SourceValidationTestcase {
+    private static final Logger log = Logger.getLogger(SourceValidationTestcase.class);
+    private static String targetURL;
+    private static final String ERROR_MESSAGE = "Error on \'(.*)\' @ Line: (.*). Position: (.*), near \'(.*)\'. ";
+
+
+    @BeforeClass
+    public static void startTest() {
+        log.info("== Prometheus source validation tests started ==");
+        targetURL = "http://localhost:9080";
+    }
+
+    @AfterClass
+    public static void shutdown() throws InterruptedException {
+        Thread.sleep(100);
+        log.info("== Prometheus source validation tests completed ==");
+    }
+
+
+    private void startSiddhiApp(String streamDefinition) {
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String siddhiApp = "@App:name('TestSiddhiApp')";
+        String outputStream = " @sink(type='log', prefix='test')" +
+                "define stream OutputStream (metric_name String, metric_type String, help String," +
+                " name String, age String, subtype String, le String, value double);";
+        String query = (
+                "@info(name = 'query') "
+                        + "from SourceTestStream "
+                        + "select * "
+                        + "insert into OutputStream;"
+        );
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(siddhiApp + streamDefinition +
+                outputStream + query);
+        InputHandler inputStream = siddhiAppRuntime.getInputHandler("SourceTestStream");
+        siddhiAppRuntime.start();
+    }
+
+    @Test(expectedExceptions = SiddhiAppCreationException.class,
+            expectedExceptionsMessageRegExp = ERROR_MESSAGE + "The field \'scheme\' contains unsupported value \'tcp" +
+                    "\' in (.*) of " + PrometheusConstants.PROMETHEUS_SOURCE)
+    public void prometheusValidationTest1() throws InterruptedException {
+
+        log.info("----------------------------------------------------------------------------------");
+        log.info("Prometheus Source test with invalid scheme");
+        log.info("----------------------------------------------------------------------------------");
+
+        String sourceStream = "@source(type='prometheus'," +
+                "target.url=\'" + targetURL + "\', " +
+                "scheme = 'tcp'," +
+                "scrape.interval = '3'," +
+                "scrape.timeout = '2'," +
+                "metric.type='histogram'," +
+                "metric.name='test_histogram'," +
+                "@map(type = 'keyvalue'))" +
+                "Define stream SourceTestStream (metric_name String, metric_type String, help String, name String," +
+                " age String, subtype String, le String, value double);";
+        startSiddhiApp(sourceStream);
+    }
+
+    @Test(expectedExceptions = SiddhiAppCreationException.class,
+            expectedExceptionsMessageRegExp = ERROR_MESSAGE + "The target URL field found empty but it is a Mandatory" +
+                    " field of " +
+                    "" + PrometheusConstants.PROMETHEUS_SOURCE + " in (.*)")
+    public void prometheusValidationTest2() throws InterruptedException {
+
+        log.info("----------------------------------------------------------------------------------");
+        log.info("Prometheus Source test with empty target URL");
+        log.info("----------------------------------------------------------------------------------");
+
+        String sourceStream = "@source(type='prometheus'," +
+                "target.url=\'\', " +
+                "scheme = 'http'," +
+                "scrape.interval = '3'," +
+                "scrape.timeout = '2'," +
+                "metric.type='histogram'," +
+                "metric.name='test_histogram'," +
+                "@map(type = 'keyvalue'))" +
+                "Define stream SourceTestStream (metric_name String, metric_type String, help String, name String," +
+                " age String, subtype String, le String, value double);";
+        startSiddhiApp(sourceStream);
+    }
+
+    @Test(expectedExceptions = SiddhiAppCreationException.class,
+            expectedExceptionsMessageRegExp = ERROR_MESSAGE + "The value \'-3\' of field \'scrape.interval\' from " +
+                    PrometheusConstants.PROMETHEUS_SOURCE + " cannot be negative in (.*)")
+    public void prometheusValidationTest3() throws InterruptedException {
+
+        log.info("----------------------------------------------------------------------------------");
+        log.info("Prometheus Source test with negative value for scrape interval");
+        log.info("----------------------------------------------------------------------------------");
+
+        String sourceStream = "@source(type='prometheus'," +
+                "target.url=\'" + targetURL + "\', " +
+                "scheme = 'http'," +
+                "scrape.interval = '-3'," +
+                "scrape.timeout = '2'," +
+                "metric.type='histogram'," +
+                "metric.name='test_histogram'," +
+                "@map(type = 'keyvalue'))" +
+                "Define stream SourceTestStream (metric_name String, metric_type String, help String, name String," +
+                " age String, subtype String, le String, value double);";
+        startSiddhiApp(sourceStream);
+    }
+
+    @Test(expectedExceptions = SiddhiAppCreationException.class,
+            expectedExceptionsMessageRegExp = ERROR_MESSAGE + "Invalid value \'time\' is found inside the field" +
+                    " \'scrape.timeout\' from " + PrometheusConstants.PROMETHEUS_SOURCE + " associated with stream \'" +
+                    "(.*)\'. Please provide a valid numeric value.")
+    public void prometheusValidationTest4() throws InterruptedException {
+
+        log.info("----------------------------------------------------------------------------------");
+        log.info("Prometheus Source test with invalid value for scrape timeout");
+        log.info("----------------------------------------------------------------------------------");
+
+        String sourceStream = "@source(type='prometheus'," +
+                "target.url=\'" + targetURL + "\', " +
+                "scheme = 'http'," +
+                "scrape.interval = '2'," +
+                "scrape.timeout = 'time'," +
+                "metric.type='histogram'," +
+                "metric.name='test_histogram'," +
+                "@map(type = 'keyvalue'))" +
+                "Define stream SourceTestStream (metric_name String, metric_type String, help String, name String," +
+                " age String, subtype String, le String, value double);";
+        startSiddhiApp(sourceStream);
+    }
+
+    @Test(expectedExceptions = SiddhiAppCreationException.class,
+            expectedExceptionsMessageRegExp = ERROR_MESSAGE + "Please provide user name and password in " +
+                    PrometheusConstants.PROMETHEUS_SOURCE + " associated with the stream ().* in Siddhi app (.*)")
+    public void prometheusValidationTest5() throws InterruptedException {
+
+        log.info("----------------------------------------------------------------------------------");
+        log.info("Prometheus Source test with either empty user name or password");
+        log.info("----------------------------------------------------------------------------------");
+
+        String sourceStream = "@source(type='prometheus'," +
+                "target.url=\'" + targetURL + "\', " +
+                "scheme = 'http'," +
+                "scrape.interval = '3'," +
+                "scrape.timeout = '2'," +
+                "username = \"\"," +
+                "password = 'abc'," +
+                "metric.type='histogram'," +
+                "metric.name='test_histogram'," +
+                "@map(type = 'keyvalue'))" +
+                "Define stream SourceTestStream (metric_name String, metric_type String, help String, name String," +
+                " age String, subtype String, le String, value double);";
+        startSiddhiApp(sourceStream);
+    }
+
+    @Test(expectedExceptions = SiddhiAppCreationException.class,
+            expectedExceptionsMessageRegExp = ERROR_MESSAGE + "Client trustStore file path or password are empty " +
+                    "while default scheme is 'https'. Please provide client trustStore file path and password in (.*)" +
+                    " of (.*)")
+    public void prometheusValidationTest6() throws InterruptedException {
+
+        log.info("----------------------------------------------------------------------------------");
+        log.info("Prometheus Source test without client trust store file or password in https scheme");
+        log.info("----------------------------------------------------------------------------------");
+
+        String sourceStream = "@source(type='prometheus'," +
+                "target.url=\'https://localhost:9080\', " +
+                "scheme = 'https'," +
+                "scrape.interval = '3'," +
+                "scrape.timeout = '2'," +
+                "client.truststore.file = \"\"," +
+                "client.truststore.password = 'abc'," +
+                "metric.type='histogram'," +
+                "metric.name='test_histogram'," +
+                "@map(type = 'keyvalue'))" +
+                "Define stream SourceTestStream (metric_name String, metric_type String, help String, name String," +
+                " age String, subtype String, le String, value double);";
+        startSiddhiApp(sourceStream);
+    }
+
+    @Test(expectedExceptions = SiddhiAppCreationException.class,
+            expectedExceptionsMessageRegExp = ERROR_MESSAGE + "The Prometheus source associated with stream (.*) " +
+                    "contains an invalid value \'hs:local-host:9080\' for target URL")
+    public void prometheusValidationTest7() throws InterruptedException {
+
+        log.info("----------------------------------------------------------------------------------");
+        log.info("Prometheus Source test with invalid target URL ");
+        log.info("----------------------------------------------------------------------------------");
+
+        String sourceStream = "@source(type='prometheus'," +
+                "target.url=\'hs:local-host:9080\', " +
+                "scheme = 'https'," +
+                "scrape.interval = '3'," +
+                "scrape.timeout = '2'," +
+                "client.truststore.file = \"\"," +
+                "client.truststore.password = 'abc'," +
+                "metric.type='histogram'," +
+                "metric.name='test_histogram'," +
+                "@map(type = 'keyvalue'))" +
+                "Define stream SourceTestStream (metric_name String, metric_type String, help String, name String," +
+                " age String, subtype String, le String, value double);";
+        startSiddhiApp(sourceStream);
+    }
+
+    @Test(expectedExceptions = SiddhiAppCreationException.class,
+            expectedExceptionsMessageRegExp = ERROR_MESSAGE + "The provided scheme and the scheme of target URL are " +
+                    "not matching in Prometheus source associated with stream (.*)")
+    public void prometheusValidationTest8() throws InterruptedException {
+
+        log.info("----------------------------------------------------------------------------------");
+        log.info("Prometheus Source test with non matching values in scheme and target URL ");
+        log.info("----------------------------------------------------------------------------------");
+
+        String sourceStream = "@source(type='prometheus'," +
+                "target.url=\'https://localhost:9080\', " +
+                "scheme = 'http'," +
+                "scrape.interval = '3'," +
+                "scrape.timeout = '2'," +
+                "metric.type='histogram'," +
+                "metric.name='test_histogram'," +
+                "@map(type = 'keyvalue'))" +
+                "Define stream SourceTestStream (metric_name String, metric_type String, help String, name String," +
+                " age String, subtype String, le String, value double);";
+        startSiddhiApp(sourceStream);
+    }
+
+    @Test(expectedExceptions = SiddhiAppCreationException.class,
+            expectedExceptionsMessageRegExp =
+                    ERROR_MESSAGE + "Invalid header format found in " + PrometheusConstants.PROMETHEUS_SOURCE + " " +
+                            "associated with stream \'(.*)\'. Please include them as " +
+                            "'key1:value1', 'key2:value2',..")
+    public void prometheusValidationTest9() throws InterruptedException {
+
+        log.info("----------------------------------------------------------------------------------");
+        log.info("Prometheus Source test with incorrect format of key-value input ");
+        log.info("----------------------------------------------------------------------------------");
+
+        String headers = "header1-value1,header2-value2";
+        String sourceStream = "@source(type='prometheus'," +
+                "target.url=\'" + targetURL + "\', " +
+                "scheme = 'http'," +
+                "scrape.interval = '3'," +
+                "headers = \'" + headers + "\'," +
+                "scrape.timeout = '2'," +
+                "metric.type='histogram'," +
+                "metric.name='test_histogram'," +
+                "@map(type = 'keyvalue'))" +
+                "Define stream SourceTestStream (metric_name String, metric_type String, help String, name String," +
+                " age String, subtype String, le String, value double);";
+        startSiddhiApp(sourceStream);
+    }
+
+    @Test(expectedExceptions = SiddhiAppCreationException.class,
+            expectedExceptionsMessageRegExp = ERROR_MESSAGE + "The \'metric.type\' field in " +
+                    PrometheusConstants.PROMETHEUS_SOURCE + " associated with stream \'(.*)\' contains illegal value")
+    public void prometheusValidationTest10() throws InterruptedException {
+
+        log.info("----------------------------------------------------------------------------------");
+        log.info("Prometheus Source test with invalid metric type ");
+        log.info("----------------------------------------------------------------------------------");
+
+        String sourceStream = "@source(type='prometheus'," +
+                "target.url=\'" + targetURL + "\', " +
+                "scheme = 'http'," +
+                "scrape.interval = '3'," +
+                "scrape.timeout = '2'," +
+                "metric.type='metric'," +
+                "metric.name='test_histogram'," +
+                "@map(type = 'keyvalue'))" +
+                "Define stream SourceTestStream (metric_name String, metric_type String, help String, name String," +
+                " age String, subtype String, le String, value double);";
+        startSiddhiApp(sourceStream);
+    }
+
+    @Test(expectedExceptions = SiddhiAppCreationException.class,
+            expectedExceptionsMessageRegExp = ERROR_MESSAGE + "The value attribute \'(.*)\' is not found " +
+                    "in " + PrometheusConstants.PROMETHEUS_SOURCE + " associated with stream \'(.*)\'")
+    public void prometheusValidationTest11() throws InterruptedException {
+
+        log.info("----------------------------------------------------------------------------------");
+        log.info("Prometheus Source test without 'value' attribute in stream definition");
+        log.info("----------------------------------------------------------------------------------");
+
+        String valueAttribute = "value";
+        String sourceStream = "@source(type='prometheus'," +
+                "target.url=\'" + targetURL + "\', " +
+                "scheme = 'http'," +
+                "scrape.interval = '3'," +
+                "value.attribute = \'" + valueAttribute + "\'," +
+                "scrape.timeout = '2'," +
+                "metric.type='histogram'," +
+                "metric.name='test_histogram'," +
+                "@map(type = 'keyvalue'))" +
+                "Define stream SourceTestStream (metric_name String, metric_type String, help String, name String," +
+                " age String, subtype String, le String);";
+        startSiddhiApp(sourceStream);
+    }
+
+    @Test(expectedExceptions = SiddhiAppCreationException.class,
+            expectedExceptionsMessageRegExp =
+                    ERROR_MESSAGE + "The attribute \'" + PrometheusConstants.VALUE_STRING + "\' " +
+                            "contains unsupported type \'STRING\' in " + PrometheusConstants.PROMETHEUS_SOURCE +
+                            " associated with stream \'(.*)\'")
+    public void prometheusValidationTest12() throws InterruptedException {
+
+        log.info("----------------------------------------------------------------------------------");
+        log.info("Prometheus Sink test with 'value' attribute in unsupported type");
+        log.info("----------------------------------------------------------------------------------");
+        String sourceStream = "@source(type='prometheus'," +
+                "target.url=\'" + targetURL + "\', " +
+                "scheme = 'http'," +
+                "scrape.interval = '3'," +
+                "scrape.timeout = '2'," +
+                "metric.type='histogram'," +
+                "metric.name='test_histogram'," +
+                "@map(type = 'keyvalue'))" +
+                "Define stream SourceTestStream (metric_name String, metric_type String, help String, name String," +
+                " age String, subtype String, le String, value string);";
+        startSiddhiApp(sourceStream);
+    }
+}

--- a/component/src/test/resources/log4j.properties
+++ b/component/src/test/resources/log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+# Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 #
 # WSO2 Inc. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except

--- a/component/src/test/resources/log4j.properties
+++ b/component/src/test/resources/log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+# Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 #
 # WSO2 Inc. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except

--- a/component/src/test/resources/prometheus/prometheus.yml
+++ b/component/src/test/resources/prometheus/prometheus.yml
@@ -16,3 +16,8 @@ scrape_configs:
   honor_labels: true
   static_configs:
   - targets: ['localhost:9091']
+
+- job_name: 'configurationTest'
+  honor_labels: true
+  static_configs:
+  - targets: ['localhost:9096']

--- a/component/src/test/resources/testng.xml
+++ b/component/src/test/resources/testng.xml
@@ -3,7 +3,7 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 
 <!--
-  ~ Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
   ~
   ~ WSO2 Inc. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except

--- a/component/src/test/resources/testng.xml
+++ b/component/src/test/resources/testng.xml
@@ -3,7 +3,7 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 
 <!--
-  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~ Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
   ~
   ~ WSO2 Inc. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
@@ -23,7 +23,9 @@
 <suite name="Siddhi-IO-Prometheus-Test-Suite">
     <test name="Siddhi-io-prometheus-tests" enabled="true">
         <classes>
-            <class name="org.wso2.extension.siddhi.io.prometheus.sink.ValidationTestcase"/>
+            <class name="org.wso2.extension.siddhi.io.prometheus.sink.SinkValidationTestcase"/>
+            <class name="org.wso2.extension.siddhi.io.prometheus.source.SourceValidationTestcase"/>
+            <class name="org.wso2.extension.siddhi.io.prometheus.source.PrometheusSourceTest"/>
         </classes>
     </test>
     <test name="Prometheus sink run tests" enabled="false">

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,9 @@
-Siddhi-io-prometheus
+﻿Siddhi-io-prometheus
 ======================================
 
-The **siddhi-io-prometheus extension** is an extension to <a target="_blank" href="https://wso2.github.io/siddhi">Siddhi</a>. It publishes siddhi events as Prometheus metrics and expose them to Prometheus server.
+The **siddhi-io-prometheus extension** is an extension to <a target="_blank" href="https://wso2.github.io/siddhi">Siddhi</a>. The Prometheus-sink publishes Siddhi events as Prometheus metrics and expose them to Prometheus 
+server. The Prometheus-source retrieves Prometheus metrics from an endpoint and send them as 
+Siddhi events.
 
 ## Prerequisites
 
@@ -12,6 +14,9 @@ Find some useful links below:
 * <a target="_blank" href="https://github.com/wso2-extensions/siddhi-io-prometheus">Source code</a>
 * <a target="_blank" href="https://github.com/wso2-extensions/siddhi-io-prometheus/releases">Releases</a>
 * <a target="_blank" href="https://github.com/wso2-extensions/siddhi-io-prometheus/issues">Issue tracker</a>
+
+## Latest API Docs
+
 
 ## How to use
 
@@ -32,17 +37,17 @@ Find some useful links below:
         <version>x.x.x</version>
      </dependency>
 ```
+## Jenkins Build Status
+
+---
+
+|  Branch | Build Status |
+| :------ |:------------ |
+| master  | [![Build Status](https://wso2.org/jenkins/job/siddhi/job/siddhi-io-prometheus/badge/icon)](https://wso2.org/jenkins/job/siddhi/job/siddhi-io-prometheus/) |
+
+---
 
 ## Features
-
-* <a target="_blank" href="https://wso2-extensions.github.io/siddhi-io-prometheus/api/1.0.0/#prometheus-sink">prometheus</a> (<a target="_blank" href="https://wso2.github.io/siddhi/documentation/siddhi-4.0/#sink">sink</a>)
-
-     The sink extension publishes events processed by WSO2 SP into Prometheus metrics and expose them to Prometheus server at the provided url. The created metrics will be published to Prometheus through,
-     
-     * 'server' publish mode : The metrics will be exposed using a http server.
-     * 'pushgateway' publish mode : The metrics will be pushed to Prometheus pushgateway. 
-     
-     The metric types that are supported by Prometheus sink are counter, gauge, histogram and summary. And the values and labels of the Prometheus metrics will be updated according to each event.
 
 
 ## How to contribute
@@ -51,8 +56,22 @@ Find some useful links below:
 * Send your contributions as pull requests to the <a target="_blank" href="https://github.com/wso2-extensions/siddhi-io-prometheus">master branch</a>.
 
 ## Running Integration tests in docker containers (Optional)
- * Integration tests are still under development.
+ * The prometheus sink can be tested with the docker base integration test framework. The test framework initialize a docker container with required configuration before execute the test suit.
+    
+   To start integration tests,
+   
+     1. Install and run docker
+     
+     2. To run the integration tests,
+     
+         - navigate to the siddhi-io-prometheus/ directory and issue the following command.
+           ```
+           mvn verify -P local-prometheus
+           ```
+ * Prometheus target configurations can be modified at the directory for integration tests : 
  
+      siddhi-io-prometheus/component/src/test/resources/prometheus/prometheus.yml
+     
 ## Contact us
  * Post your questions with the <a target="_blank" href="http://stackoverflow.com/search?q=siddhi">"Siddhi"</a> tag in <a target="_blank" href="http://stackoverflow.com/search?q=siddhi">Stackoverflow</a>.
 

--- a/docs/license.md
+++ b/docs/license.md
@@ -1,4 +1,4 @@
-Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 
 WSO2 Inc. licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 

--- a/docs/license.md
+++ b/docs/license.md
@@ -1,4 +1,4 @@
-Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 
 WSO2 Inc. licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+~ Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 ~
 ~ WSO2 Inc. licenses this file to you under the Apache License,
 ~ Version 2.0 (the "License"); you may not use this file except
@@ -106,6 +106,27 @@
                 <version>${keyvalue.mapper.version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.messaging</groupId>
+                <artifactId>org.wso2.carbon.messaging</artifactId>
+                <version>${org.wso2.carbon.messaging.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.transport.http</groupId>
+                <artifactId>org.wso2.transport.http.netty</artifactId>
+                <version>${org.wso2.transport.http.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.transport.http</groupId>
+                <artifactId>org.wso2.transport.http.netty.feature</artifactId>
+                <version>${org.wso2.transport.http.version}</version>
+                <type>zip</type>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-all</artifactId>
+                <version>${io.netty.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <build>
@@ -163,5 +184,8 @@
         <skip.surefire.test>false</skip.surefire.test>
         <prometheus-test.port>9090</prometheus-test.port>
         <prometheus-pushgateway-test.port>9091</prometheus-pushgateway-test.port>
+        <org.wso2.transport.http.version>6.0.163</org.wso2.transport.http.version>
+        <org.wso2.carbon.messaging.version>3.0.2</org.wso2.carbon.messaging.version>
+        <io.netty.version>4.1.16.Final</io.netty.version>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-~ Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 ~
 ~ WSO2 Inc. licenses this file to you under the Apache License,
 ~ Version 2.0 (the "License"); you may not use this file except


### PR DESCRIPTION
## Purpose
> The purpose is to enable Siddhi to consume Prometheus metrics which are exported in an HTTP endpoint as Siddhi events.

## Goals
> The source extension for siddhi-io-prometheus will consume Prometheus metrics that are exposed at a given URL and send them as Siddhi events to be processed by WSO2 SP.

## Approach
> The Prometheus source allows the user to retrieve metrics from a given URL by making continuous HTTP requests and to receive the metric data through a predefined key-value map. It enables the user to specify the required metric through the <a target="_blank" href="https://prometheus.io/docs/concepts/metric_types/">metric type</a>, metric name, <a target="_blank" href="https://prometheus.io/docs/concepts/jobs_instances/">job name</a>, instance and grouping keys. The supported metric types are counter, gauge, histogram, and summary.

## User stories
> The user story can be found <a target="_blank" href="https://docs.google.com/document/d/1_lCn9hOdYkbG6hnYrqnB1Ww2ds5zMfFa9aJZFQjWY0E/edit?usp=sharing">here</a>.

## Release note
> Prometheus io source extension will allow Siddhi to consume Prometheus metrics as Siddhi events.

## Documentation
> Please find the documentation in this <a target="_blank" href="https://github.com/HindujaB/siddhi-io-prometheus/blob/0c940aac8e967d319d3311cde48ee08adfc19b24/component/src/main/java/org/wso2/extension/siddhi/io/prometheus/source/PrometheusSource.java#L54">file</a> within annotations.

## Training
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > around 88% of code coverage.

## Security checks
  - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
> yes
 - Ran FindSecurityBugs plugin and verified report? 
> yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
> yes

## Samples
```
@source(type= 'prometheus', target.url= 'http://localhost:9080/metrics', metric.type= 'counter',metric.name= 'sweet_production_counter', 
@map(type= ‘keyvalue’))
define stream FooStream1(metric_name string, metric_type string, help string, subtype string, name string, quantity string, value double)
```
In this example, the prometheus source makes an http request to the \'target.url\' and analyse the response.
From the response, the source retrieves the Prometheus counter metrics with the name, 'sweet_production_counter'
and converts the filtered metrics into Siddhi events using the key-value mapper.
The generated maps will have keys and values as follows: 
metric_name  -> sweet_production_counter
metric_type  -> counter
help  -> <help_string_of_metric>
subtype  -> null
name -> <value_of_label_name>
quantity -> <value_of_label_quantity>
value -> <value_of_metric>

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
  * JDK version: 1.8
  * Operating system: Ubuntu 18.04
  * Prometheus release version: 2.5.0 
 
## Learning
  * <a target="_blank" href="https://prometheus.io/docs/introduction/overview/">Prometheus</a> documentation. 
  * Prometheus java <a target="_blank" href="https://github.com/prometheus/client_java/blob/master/README.md">client</a>.
