### PR TITLE
Remove Prometheus client dependency package

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -254,16 +254,14 @@
                             io.siddhi.extension.io.prometheus.*
                         </Export-Package>
                         <Import-Package>
-                            io.prometheus.client.exporter.*; version="${prometheus.client.version.range}"
-                            io.siddhi.*; version="${siddhi.import.version.range}"
+                            io.prometheus.client.exporter.*; version="${prometheus.client.version.range}",
+                            io.siddhi.*; version="${siddhi.import.version.range}",
+                            io.prometheus.client.exporter.*
                         </Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>
                         <Include-Resource>
                             META-INF=target/classes/META-INF
                         </Include-Resource>
-                        <Private-Package>
-                            io.prometheus.client.exporter.*
-                        </Private-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -255,8 +255,7 @@
                         </Export-Package>
                         <Import-Package>
                             io.prometheus.client.exporter.*; version="${prometheus.client.version.range}",
-                            io.siddhi.*; version="${siddhi.import.version.range}",
-                            io.prometheus.client.exporter.*
+                            io.siddhi.*; version="${siddhi.import.version.range}"
                         </Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>
                         <Include-Resource>


### PR DESCRIPTION
## Purpose
Remove Prometheus client dependency package

## Goals
Prevent the conflicts of siddhi-io-prometheus and Prometheus Metrics Reporter.

## Approach
Add the prometheus dependency jars in siddhi-io-prometheus to Import-Package and add them to Export-Package in Prometheus Reporter.