### PR TITLE
Fix Prometheus bundle loading issue

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -259,8 +259,10 @@
                             io.siddhi.extension.io.prometheus.*
                         </Export-Package>
                         <Import-Package>
-                            io.prometheus.client.exporter.*; version="${prometheus.client.version.range}",
-                            io.siddhi.*; version="${siddhi.import.version.range}"
+                            io.siddhi.core.*;version="${siddhi.import.version.range}",
+                            io.siddhi.annotation.*;version="${siddhi.import.version.range}",
+                            io.siddhi.query.api.*;version="${siddhi.import.version.range}",
+                            io.prometheus.client.exporter.*
                         </Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>
                         <Include-Resource>

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,6 @@
     <properties>
         <siddhi.version>5.1.4</siddhi.version>
         <siddhi.import.version.range>[5.0.0,6.0.0)</siddhi.import.version.range>
-        <prometheus.client.version.range>[0.5.0,)</prometheus.client.version.range>
         <log4j.version>1.2.17.wso2v1</log4j.version>
         <carbon.transport.version>4.4.15</carbon.transport.version>
         <siddhi.map.json.version>5.0.4</siddhi.map.json.version>


### PR DESCRIPTION
## Purpose
> Siddhi IO Prometheus extension is not loading in latest Siddhi release due to recent changes related to import packages. This PR fix those issues.
